### PR TITLE
mod pro/demotion commands fixes and security

### DIFF
--- a/server/commands/demod.php
+++ b/server/commands/demod.php
@@ -3,54 +3,73 @@
 
 require_once(__DIR__ . '/../fns/db_fns.php');
 
-$port = $argv[1];
-$user_name = $argv[2];
-$admin = $argv[3]; // player passed as argument for use with confirmation/error messages
-$caught_exception = false;
+function demote_mod($port, $user_name, $admin, $demoted_player) {
 
-// if the user isn't an admin, kill the script
-if($admin->group != 3) {
-	echo $admin->name." lacks the power to demote. Quitting...";
-	$admin->write("message`Error: You lack the power to demote $user_name.");
-	exit;
-}
-
-try {
-	$connection = user_connect();
-	$user_id = name_to_id($connection, $user_name);
-	$safe_user_id = addslashes($user_id);
-
-
-	//delete mod entry
-	$result = $connection->query("DELETE FROM mod_power
-									WHERE user_id = '$safe_user_id'");
-	if(!$result) {
-		throw new Exception('Could not delete the moderator type from database.');
+	// boolean var for use in if statement @end
+	$caught_exception = false;
+	
+	// if the user isn't an admin on the server, kill the function (2nd line of defense)
+	if($admin->group != 3) {
+		$caught_exception = true;
+		echo $admin->name." lacks the server power to demote $user_name.";
+		$admin->write("message`Error: You lack the power to demote $user_name.");
+		return false;
 	}
+	
+	try {
+		$connection = user_connect();
+		$user_id = name_to_id($connection, $user_name);
+		$safe_admin_id = addslashes($admin->user_id);
+		$safe_user_id = addslashes($user_id);
+		
+		//check for proper permission in the db (3rd + final line of defense before promotion)
+		$result = $connection->query("SELECT *
+										FROM users
+										WHERE user_id = '$safe_admin_id'
+										LIMIT 0,1",
+										MYSQLI_ASYNC);
+		$row = $result->fetch_object();
+		if($row->power != 3) {
+			throw new Exception("You lack the power to demote $user_name.");
+		}
+	
+		//delete mod entry
+		$result = $connection->query("DELETE FROM mod_power
+										WHERE user_id = '$safe_user_id'",
+										MYSQLI_ASYNC);
+		if(!$result) {
+			throw new Exception("Could not delete the moderator type from the database because $user_name isn\'t a moderator.");
+		}
 
-
-	//set power to 1
-	$result = $connection->query("UPDATE users
-									SET power = 1
-									WHERE user_id = '$safe_user_id'");
-	if(!$result) {
-		throw new Exception("Could not demote $user_name to a member.");
+	
+		//set power to 1
+		$result = $connection->query("UPDATE users
+										SET power = 1
+										WHERE user_id = '$safe_user_id'",
+										MYSQLI_ASYNC);
+		if(!$result) {
+			throw new Exception("Could not demote $user_name due to a database error.");
+		}
 	}
+	
+	catch(Exception $e){
+		$caught_exception = true;
+		$message = $e->getMessage();
+		echo "Error: "$message;
+		$admin->write("message`Error: $message");
+		return false;
+	}
+	
+	if(!$caught_exception) {
+		if(isset($demoted_player) && $demoted_player->group >= 2) {
+			$demoted_player->group = 1;
+			$demoted_player->write('setGroup`1');
+		}
+		echo $admin->name." demoted $user_name.";
+		$admin->write("message`$user_name has been demoted.");
+		return true;
+	}
+	
 }
-
-catch(Exception $e){
-	$caught_exception = true;
-	$message = $e->getMessage();
-	echo $message;
-	$admin->write("message`Error: $message");
-	exit;
-}
-
-if(!$caught_exception) {
-	$admin->write("message`$user_name has been successfully demoted to a member.");
-	exit;
-}
-
-exit;
 
 ?>

--- a/server/commands/demod.php
+++ b/server/commands/demod.php
@@ -5,6 +5,15 @@ require_once(__DIR__ . '/../fns/db_fns.php');
 
 $port = $argv[1];
 $user_name = $argv[2];
+$admin = $argv[3]; // player passed as argument for use with confirmation/error messages
+$caught_exception = false;
+
+// if the user isn't an admin, kill the script
+if($admin->group != 3) {
+	echo $admin->name." lacks the power to demote. Quitting...";
+	$admin->write("message`Error: You lack the power to demote $user_name.");
+	exit;
+}
 
 try {
 	$connection = user_connect();
@@ -16,7 +25,7 @@ try {
 	$result = $connection->query("DELETE FROM mod_power
 									WHERE user_id = '$safe_user_id'");
 	if(!$result) {
-		throw new Exception('could not delete mod row');
+		throw new Exception('Could not delete the moderator type from database.');
 	}
 
 
@@ -25,14 +34,23 @@ try {
 									SET power = 1
 									WHERE user_id = '$safe_user_id'");
 	if(!$result) {
-		throw new Exception('Could not set user power');
+		throw new Exception("Could not demote $user_name to a member.");
 	}
 }
 
 catch(Exception $e){
+	$caught_exception = true;
 	$message = $e->getMessage();
 	echo $message;
+	$admin->write("message`Error: $message");
 	exit;
 }
+
+if(!$caught_exception) {
+	$admin->write("message`$user_name has been successfully demoted to a member.");
+	exit;
+}
+
+exit;
 
 ?>

--- a/server/commands/promote_to_moderator.php
+++ b/server/commands/promote_to_moderator.php
@@ -6,14 +6,14 @@ require_once(__DIR__ . '/../fns/db_fns.php');
 $port = $argv[1];
 $name = $argv[2];
 $type = $argv[3];
-$admin = $argv[4]; // argument passed as a player for use with error/confirmation messages
+$admin = $argv[4]; // player passed as argument for use with error/confirmation messages
 $caught_exception = false;
 
 // if the user isn't an admin, kill the script
 if($admin->group != 3) {
 	echo $admin->name." lacks the power to promote. Quitting...";
 	$admin->write("message`Error: You lack the power to promote $name to a $type moderator.");
-	exit();
+	exit;
 }
 
 try {
@@ -109,12 +109,12 @@ catch(Exception $e){
 	$caught_exception = true;
 	echo $e->getMessage();
 	$admin->write('message`Error: '.$e->getMessage());
+	exit;
 }
 
 if (!$caught_exception) {
 	$admin->write("message`$name has been promoted to a $type moderator!");
+	exit;
 }
-
-exit();
 
 ?>

--- a/server/commands/promote_to_moderator.php
+++ b/server/commands/promote_to_moderator.php
@@ -11,7 +11,7 @@ function promote_mod($port, $name, $type, $admin) {
 	// if the user isn't an admin on the server, kill the function (2nd line of defense)
 	if($admin->group != 3) {
 		$caught_exception = true;
-		echo $admin->name." lacks the power to promote. Quitting...";
+		echo $admin->name." lacks the server power to promote $name to a $type moderator.";
 		$admin->write("message`Error: You lack the power to promote $name to a $type moderator.");
 		return false;
 	}

--- a/server/commands/promote_to_moderator.php
+++ b/server/commands/promote_to_moderator.php
@@ -3,7 +3,7 @@
 
 require_once(__DIR__ . '/../fns/db_fns.php');
 
-function promote_to_moderator($port, $name, $type, $admin) {
+function promote_mod($port, $name, $type, $admin) {
 	
 	// boolean var for use in if statement @end
 	$caught_exception = false;
@@ -11,7 +11,7 @@ function promote_to_moderator($port, $name, $type, $admin) {
 	// if the user isn't an admin on the server, kill the function (2nd line of defense)
 	if($admin->group != 3) {
 		$caught_exception = true;
-		echo $admin->name." lacks the power to promote $name to a $type moderator.";
+		echo $admin->name." lacks the power to promote. Quitting...";
 		$admin->write("message`Error: You lack the power to promote $name to a $type moderator.");
 		return false;
 	}

--- a/server/commands/promote_to_moderator.php
+++ b/server/commands/promote_to_moderator.php
@@ -3,118 +3,138 @@
 
 require_once(__DIR__ . '/../fns/db_fns.php');
 
-$port = $argv[1];
-$name = $argv[2];
-$type = $argv[3];
-$admin = $argv[4]; // player passed as argument for use with error/confirmation messages
-$caught_exception = false;
+function promote_to_moderator($port, $name, $type, $admin) {
+	
+	// boolean var for use in if statement @end
+	$caught_exception = false;
 
-// if the user isn't an admin, kill the script
-if($admin->group != 3) {
-	echo $admin->name." lacks the power to promote. Quitting...";
-	$admin->write("message`Error: You lack the power to promote $name to a $type moderator.");
-	exit;
-}
-
-try {
-
-	//sanity check
-	if($type != 'trial' && $type != 'permanent') {
-		throw new Exception('Invalid moderator type.');
+	// if the user isn't an admin on the server, kill the function (2nd line of defense)
+	if($admin->group != 3) {
+		$caught_exception = true;
+		echo $admin->name." lacks the power to promote $name to a $type moderator.";
+		$admin->write("message`Error: You lack the power to promote $name to a $type moderator.");
+		return false;
 	}
 
-	$connection = user_connect();
-	$user_id = name_to_id($connection, $name);
-	$safe_user_id = addslashes($user_id);
-	$safe_type = addslashes($type);
-	$safe_time = addslashes(time());
-	$safe_min_time = addslashes(time()-(60*60*6));
-
-	//throttle mod promotions
-	$result = $connection->query("SELECT COUNT(*) as recent_promotion_count
-									FROM promotion_log
-									WHERE power > 1
-									AND time > $safe_min_time");
-	if(!$result) {
-		throw new Exception('Could not check for recent promotions.');
-	}
-
-	$row = $result->fetch_object();
-	if($row->recent_promotion_count > 0) {
-		throw new Exception('Someone has already been promoted to a moderator recently. Wait a bit before trying to promote again.');
+	try {
+	
+		//sanity check
+		if($type != 'trial' && $type != 'permanent') {
+			throw new Exception('Invalid moderator type.');
+		}
+	
+		$connection = user_connect();
+		$user_id = name_to_id($connection, $name);
+		$safe_admin_id = addslashes($admin->user_id);
+		$safe_user_id = addslashes($user_id);
+		$safe_type = addslashes($type);
+		$safe_time = addslashes(time());
+		$safe_min_time = addslashes(time()-(60*60*6));
+	
+		//throttle mod promotions
+		$result = $connection->query("SELECT COUNT(*) as recent_promotion_count
+										FROM promotion_log
+										WHERE power > 1
+										AND time > $safe_min_time",
+										MYSQLI_ASYNC);
+		if(!$result) {
+			throw new Exception('Could not check for recent promotions.');
+		}
+	
+		$row = $result->fetch_object();
+		if($row->recent_promotion_count > 0) {
+			throw new Exception('Someone has already been promoted to a moderator recently. Wait a bit before trying to promote again.');
+		}
+		
+		//check for guest
+		$result = $connection->query("SELECT *
+										FROM users
+										WHERE user_id = '$safe_user_id'
+										LIMIT 0,1",
+										MYSQLI_ASYNC);
+		$row = $result->fetch_object();
+		if($row->power < 1) {
+			throw new Exception('Guests can\'t be promoted to moderators.');
+		}
+		
+		//check for proper permission in the db (3rd + final line of defense before promotion)
+		$result = $connection->query("SELECT *
+										FROM users
+										WHERE user_id = '$safe_admin_id'
+										LIMIT 0,1",
+										MYSQLI_ASYNC);
+		$row = $result->fetch_object();
+		if($row->power != 3) {
+			throw new Exception("You lack the power to promote $name to a $type moderator.");
+		}
+	
+		//log the power change
+		$result = $connection->query("INSERT INTO promotion_log
+									 	SET message = 'user_id: $safe_user_id has been promoted to $safe_type moderator',
+											power = 2,
+											time = '$safe_time'",
+											MYSQLI_ASYNC);
+		if(!$result) {
+			throw new Exception('Could not record the promotion in the database.');
+		}
+	
+		//do the power change
+		$result = $connection->query("update users
+										set power = 2
+										where user_id = '$safe_user_id'",
+										MYSQLI_ASYNC);
+		if(!$result){
+			throw new Exception("Could not promote $name to a $type moderator.");
+		}
+	
+		//set power limits
+		if($type == 'trial') {
+			$max_ban = 60 * 60 * 24;
+			$bans_per_hour = 30;
+			$can_unpublish_level = 0;
+		}
+		if($type == 'permanent') {
+			$max_ban = 31536000; // 1 year
+			$bans_per_hour = 101;
+			$can_unpublish_level = 1;
+		}
+	
+		$safe_max_ban = $connection->real_escape_string($max_ban);
+		$safe_bans_per_hour = $connection->real_escape_string($bans_per_hour);
+		$safe_can_unpublish_level = $connection->real_escape_string($can_unpublish_level);
+	
+		$result = $connection->query("INSERT INTO mod_power
+										SET user_id = '$safe_user_id',
+											max_ban = '$safe_max_ban',
+											bans_per_hour = '$safe_bans_per_hour',
+											can_ban_ip = '1',
+											can_ban_account = '1',
+											can_unpublish_level = '$safe_can_unpublish_level'
+										ON DUPLICATE KEY UPDATE
+											max_ban = '$safe_max_ban',
+											bans_per_hour = '$safe_bans_per_hour',
+											can_ban_ip = '1',
+											can_ban_account = '1',
+											can_unpublish_level = '$safe_can_unpublish_level'",
+											MYSQLI_ASYNC);
+		if(!$result) {
+			throw new Exception('Could not set limits on the new moderator\'s power.');
+		}
 	}
 	
-	//check for guest
-	$result = $connection->query("SELECT *
-									FROM users
-									WHERE user_id = '$safe_user_id'
-									LIMIT 0,1");
-	$row = $result->fetch_object();
-	if($row->power < 1) {
-		throw new Exception('Guests can\'t be promoted to moderators.');
+	catch(Exception $e){
+		$caught_exception = true;
+		echo $e->getMessage();
+		$admin->write('message`Error: '.$e->getMessage());
+		return false;
+	}
+	
+	if (!$caught_exception) {
+		echo $admin->name." promoted $name to a $type moderator.";
+		$admin->write("message`$name has been promoted to a $type moderator!");
+		return true;
 	}
 
-	//log the power change
-	$result = $connection->query("INSERT INTO promotion_log
-								 	SET message = 'user_id: $safe_user_id has been promoted to $safe_type moderator',
-										power = 2,
-										time = '$safe_time'");
-	if(!$result) {
-		throw new Exception('Could not record the promotion.');
-	}
-
-	//do the power change
-	$result = $connection->query("update users
-									set power = 2
-									where user_id = '$safe_user_id'");
-	if(!$result){
-		throw new Exception("Could not promote $name to a $type moderator.");
-	}
-
-	//set limits
-	if($type == 'trial') {
-		$max_ban = 60 * 60 * 24;
-		$bans_per_hour = 30;
-		$can_unpublish_level = 0;
-	}
-	if($type == 'permanent') {
-		$max_ban = 31536000; // 1 year
-		$bans_per_hour = 101;
-		$can_unpublish_level = 1;
-	}
-
-	$safe_max_ban = $connection->real_escape_string($max_ban);
-	$safe_bans_per_hour = $connection->real_escape_string($bans_per_hour);
-	$safe_can_unpublish_level = $connection->real_escape_string($can_unpublish_level);
-
-	$result = $connection->query("INSERT INTO mod_power
-									SET user_id = '$safe_user_id',
-										max_ban = '$safe_max_ban',
-										bans_per_hour = '$safe_bans_per_hour',
-										can_ban_ip = '1',
-										can_ban_account = '1',
-										can_unpublish_level = '$safe_can_unpublish_level'
-									ON DUPLICATE KEY UPDATE
-										max_ban = '$safe_max_ban',
-										bans_per_hour = '$safe_bans_per_hour',
-										can_ban_ip = '1',
-										can_ban_account = '1',
-										can_unpublish_level = '$safe_can_unpublish_level'");
-	if(!$result) {
-		throw new Exception('Could not set limits on the new moderator\'s power.');
-	}
-}
-
-catch(Exception $e){
-	$caught_exception = true;
-	echo $e->getMessage();
-	$admin->write('message`Error: '.$e->getMessage());
-	exit;
-}
-
-if (!$caught_exception) {
-	$admin->write("message`$name has been promoted to a $type moderator!");
-	exit;
 }
 
 ?>

--- a/server/commands/promote_to_moderator.php
+++ b/server/commands/promote_to_moderator.php
@@ -3,11 +3,11 @@
 
 require_once(__DIR__ . '/../fns/db_fns.php');
 
-function promote_mod($port, $name, $type, $admin) {
+function promote_mod($port, $name, $type, $admin, $promoted_player) {
 	
 	// boolean var for use in if statement @end
 	$caught_exception = false;
-
+	
 	// if the user isn't an admin on the server, kill the function (2nd line of defense)
 	if($admin->group != 3) {
 		$caught_exception = true;
@@ -15,125 +15,188 @@ function promote_mod($port, $name, $type, $admin) {
 		$admin->write("message`Error: You lack the power to promote $name to a $type moderator.");
 		return false;
 	}
+	
+	// define variables needed
+	$connection = user_connect();
+	$user_id = name_to_id($connection, $name);
+	$safe_admin_id = addslashes($admin->user_id);
+	$safe_user_id = addslashes($user_id);
+	$safe_type = addslashes($type);
+	$safe_time = addslashes(time());
+	$safe_min_time = addslashes(time()-(60*60*6));
+	
+	// get info about the person promoting
+	$admin_result = $connection->query("SELECT *
+									FROM users
+									WHERE user_id = '$safe_admin_id'
+									LIMIT 0,1",
+									MYSQLI_ASYNC);
+	$admin_row = $result->fetch_object();
 
-	try {
-	
-		//sanity check
-		if($type != 'trial' && $type != 'permanent') {
-			throw new Exception('Invalid moderator type.');
-		}
-	
-		$connection = user_connect();
-		$user_id = name_to_id($connection, $name);
-		$safe_admin_id = addslashes($admin->user_id);
-		$safe_user_id = addslashes($user_id);
-		$safe_type = addslashes($type);
-		$safe_time = addslashes(time());
-		$safe_min_time = addslashes(time()-(60*60*6));
-	
-		//throttle mod promotions
-		$result = $connection->query("SELECT COUNT(*) as recent_promotion_count
-										FROM promotion_log
-										WHERE power > 1
-										AND time > $safe_min_time",
-										MYSQLI_ASYNC);
-		if(!$result) {
-			throw new Exception('Could not check for recent promotions.');
-		}
-	
-		$row = $result->fetch_object();
-		if($row->recent_promotion_count > 0) {
-			throw new Exception('Someone has already been promoted to a moderator recently. Wait a bit before trying to promote again.');
-		}
-		
-		//check for guest
-		$result = $connection->query("SELECT *
-										FROM users
-										WHERE user_id = '$safe_user_id'
-										LIMIT 0,1",
-										MYSQLI_ASYNC);
-		$row = $result->fetch_object();
-		if($row->power < 1) {
-			throw new Exception('Guests can\'t be promoted to moderators.');
-		}
-		
-		//check for proper permission in the db (3rd + final line of defense before promotion)
-		$result = $connection->query("SELECT *
-										FROM users
-										WHERE user_id = '$safe_admin_id'
-										LIMIT 0,1",
-										MYSQLI_ASYNC);
-		$row = $result->fetch_object();
-		if($row->power != 3) {
-			throw new Exception("You lack the power to promote $name to a $type moderator.");
-		}
-	
-		//log the power change
-		$result = $connection->query("INSERT INTO promotion_log
-									 	SET message = 'user_id: $safe_user_id has been promoted to $safe_type moderator',
-											power = 2,
-											time = '$safe_time'",
-											MYSQLI_ASYNC);
-		if(!$result) {
-			throw new Exception('Could not record the promotion in the database.');
-		}
-	
-		//do the power change
-		$result = $connection->query("update users
-										set power = 2
-										where user_id = '$safe_user_id'",
-										MYSQLI_ASYNC);
-		if(!$result){
-			throw new Exception("Could not promote $name to a $type moderator.");
-		}
-	
-		//set power limits
-		if($type == 'trial') {
-			$max_ban = 60 * 60 * 24;
-			$bans_per_hour = 30;
-			$can_unpublish_level = 0;
-		}
-		if($type == 'permanent') {
-			$max_ban = 31536000; // 1 year
-			$bans_per_hour = 101;
-			$can_unpublish_level = 1;
-		}
-	
-		$safe_max_ban = $connection->real_escape_string($max_ban);
-		$safe_bans_per_hour = $connection->real_escape_string($bans_per_hour);
-		$safe_can_unpublish_level = $connection->real_escape_string($can_unpublish_level);
-	
-		$result = $connection->query("INSERT INTO mod_power
-										SET user_id = '$safe_user_id',
-											max_ban = '$safe_max_ban',
-											bans_per_hour = '$safe_bans_per_hour',
-											can_ban_ip = '1',
-											can_ban_account = '1',
-											can_unpublish_level = '$safe_can_unpublish_level'
-										ON DUPLICATE KEY UPDATE
-											max_ban = '$safe_max_ban',
-											bans_per_hour = '$safe_bans_per_hour',
-											can_ban_ip = '1',
-											can_ban_account = '1',
-											can_unpublish_level = '$safe_can_unpublish_level'",
-											MYSQLI_ASYNC);
-		if(!$result) {
-			throw new Exception('Could not set limits on the new moderator\'s power.');
-		}
-	}
-	
-	catch(Exception $e){
+	//check for proper permission in the db (3rd + final line of defense before promotion)
+	if($admin_row->power != 3) {
 		$caught_exception = true;
-		echo $e->getMessage();
-		$admin->write('message`Error: '.$e->getMessage());
+		echo $admin->name." lacks the database power to promote $name to a $type moderator.";
+		$admin->write("message`Error: You lack the power to promote $name to a $type moderator.");
 		return false;
 	}
 	
+	// get info about the person being promoted
+	$user_result = $connection->query("SELECT *
+									FROM users
+									WHERE user_id = '$safe_user_id'
+									LIMIT 0,1",
+									MYSQLI_ASYNC);
+	$user_row = $result->fetch_object();
+	
+	// if the person being promoted is a guest, end the function
+	if($user_row->power < 1) {
+		$caught_exception = true;
+		echo $admin->name." tried to promote a guest ($name) to a $type moderator.";
+		$admin->write("message`Error: Guests can\'t be promoted to moderators.");
+		return false;
+	}
+	
+	// if the person being promoted doesn't exist, end the function
+	if(count($user_row) < 1) {
+		$caught_exception = true;
+		echo $admin->name." tried to promote a user that doesn\'t exist ($name) to a $type moderator.";
+		$admin->write("message`Error: $name doesn\'t exist.");
+		return false;
+	}
+	
+	// now that we've determined that the user is able to do what they're trying to do, let's finish
+	
+	// if type is trial or permanent, do promotion things in the db
+	if ($type == 'trial' || $type == 'permanent') {
+	
+		try {
+		
+			//throttle mod promotions
+			$result = $connection->query("SELECT COUNT(*) as recent_promotion_count
+											FROM promotion_log
+											WHERE power > 1
+											AND time > $safe_min_time",
+											MYSQLI_ASYNC);
+			if(!$result) {
+				throw new Exception('Could not check for recent promotions.');
+			}
+		
+			$row = $result->fetch_object();
+			if($row->recent_promotion_count > 0) {
+				throw new Exception('Someone has already been promoted to a moderator recently. Wait a bit before trying to promote again.');
+			}
+		
+			//log the power change
+			$result = $connection->query("INSERT INTO promotion_log
+										 	SET message = 'user_id: $safe_user_id has been promoted to $safe_type moderator',
+												power = 2,
+												time = '$safe_time'",
+												MYSQLI_ASYNC);
+			if(!$result) {
+				throw new Exception('Could not record the promotion in the database.');
+			}
+		
+			//do the power change
+			$result = $connection->query("update users
+											set power = 2
+											where user_id = '$safe_user_id'",
+											MYSQLI_ASYNC);
+			if(!$result){
+				throw new Exception("Could not promote $name to a $type moderator.");
+			}
+		
+			//set power limits
+			if($type == 'trial') {
+				$max_ban = 60 * 60 * 24;
+				$bans_per_hour = 30;
+				$can_unpublish_level = 0;
+			}
+			if($type == 'permanent') {
+				$max_ban = 31536000; // 1 year
+				$bans_per_hour = 101;
+				$can_unpublish_level = 1;
+			}
+		
+			$safe_max_ban = $connection->real_escape_string($max_ban);
+			$safe_bans_per_hour = $connection->real_escape_string($bans_per_hour);
+			$safe_can_unpublish_level = $connection->real_escape_string($can_unpublish_level);
+		
+			$result = $connection->query("INSERT INTO mod_power
+											SET user_id = '$safe_user_id',
+												max_ban = '$safe_max_ban',
+												bans_per_hour = '$safe_bans_per_hour',
+												can_ban_ip = '1',
+												can_ban_account = '1',
+												can_unpublish_level = '$safe_can_unpublish_level'
+											ON DUPLICATE KEY UPDATE
+												max_ban = '$safe_max_ban',
+												bans_per_hour = '$safe_bans_per_hour',
+												can_ban_ip = '1',
+												can_ban_account = '1',
+												can_unpublish_level = '$safe_can_unpublish_level'",
+												MYSQLI_ASYNC);
+			if(!$result) {
+				throw new Exception('Could not set limits on the new moderator\'s power.');
+			}
+		}
+		
+		catch(Exception $e){
+			$caught_exception = true;
+			$promoted_player = NULL;
+			echo "Error: ".$e->getMessage();
+			$admin->write('message`Error: '.$e->getMessage());
+			return false;
+		}
+
+	} // end if trial/permanent
+	
+	elseif ($type == 'temporary') {
+	
+		try {
+		
+			//check for proper permission in the db (3rd + final line of defense before promotion)
+			$result = $connection->query("SELECT *
+											FROM users
+											WHERE user_id = '$safe_admin_id'
+											LIMIT 0,1",
+											MYSQLI_ASYNC);
+			$row = $result->fetch_object();
+			if($row->power != 3) {
+				throw new Exception("You lack the power to promote $name to a $type moderator.");
+			}
+			
+		}
+		
+		catch(Exception $e){
+			$caught_exception = true;
+			$promoted_player = NULL;
+			echo "Error: ".$e->getMessage();
+			$admin->write('message`Error: '.$e->getMessage());
+			return false;
+		}
+		
+	} // end if temp
+	
+	// if all of that was valid and error-less, carry out the client-side changes
 	if (!$caught_exception) {
+		if(isset($promoted_player) && $promoted_player->group != 0 && $type == 'temporary'){
+				$promoted_player->become_temp_mod();
+		}
+		elseif(isset($promoted_player) && $promoted_player->group != 0 && ($type == 'trial' || $type == 'permanent')){
+				$promoted_player->group = 2;
+				$promoted_player->write('setGroup`2');
+		}
+		else {
+				echo $admin->name." tried to promote $name to an invalid type of moderator ($type).";
+				$admin->write("message`Error: Invalid moderator type.");
+				return false;
+		}
 		echo $admin->name." promoted $name to a $type moderator.";
 		$admin->write("message`$name has been promoted to a $type moderator!");
 		return true;
 	}
+	
 
 }
 

--- a/server/pr2_moderation.php
+++ b/server/pr2_moderation.php
@@ -149,9 +149,9 @@ function promote_to_moderator($socket, $data){
 	$to_player = name_to_player($name); // define before if
 
 	// if they're an admin and not trying to promote a guest, continue with the promotion
-	if(($from_player->group > 2) && ($to_player->group != 0)){
+	if($from_player->group > 2){
 					// promoting guests breaks their accounts
-		if(isset($to_player)){
+		if(isset($to_player) && $to_player->group != 0){
 			if($type == 'temporary') {
 				$to_player->become_temp_mod();
 			}
@@ -161,13 +161,11 @@ function promote_to_moderator($socket, $data){
 			}
 		}
 
-		// give a confirmation message
-		$from_player->write('message`'.$name.' has been promoted to a '.$type.' moderator!');
-
 		if($type == 'permanent' || $type == 'trial') {
 			global $port;
+			$safe_admin = escapeshellarg($from_player);
 			$safe_name = escapeshellarg($name);
-			exec("nohup php ".__DIR__."/promote_to_moderator.php $port $safe_name $type > /dev/null &");
+			exec("nohup php ".__DIR__."/commands/promote_to_moderator.php $port $safe_name $type $safe_admin > /dev/null &");
 		}
 
 		switch($type) {
@@ -219,7 +217,7 @@ function demote_moderator($socket, $name) {
 		}
 		global $port;
 		$safe_name = escapeshellarg($name);
-		exec("nohup php ".__DIR__."/demod.php $port $safe_name > /dev/null &");
+		exec("nohup php ".__DIR__."/commands/demod.php $port $safe_name > /dev/null &");
 	}
 }
 
@@ -227,7 +225,7 @@ function demote_moderator($socket, $name) {
 //--- ban yourself ---
 function ban_socket($socket) {
 	$player = $socket->get_player();
-	exec('nohup php '.__DIR__.'/ban.php '.escapeshellarg($player->user_id).' '.escapeshellarg($socket->remote_address).' '.escapeshellarg($player->name).' > /dev/null &');
+	exec('nohup php '.__DIR__.'/commands/ban.php '.escapeshellarg($player->user_id).' '.escapeshellarg($socket->remote_address).' '.escapeshellarg($player->name).' > /dev/null &');
 	$socket->close();
 	$socket->on_disconnect();
 }

--- a/server/pr2_moderation.php
+++ b/server/pr2_moderation.php
@@ -207,17 +207,14 @@ function demote_moderator($socket, $name) {
 
 	if($from_player->group == 3){
 		$to_player = name_to_player($name);
-		if(isset($to_player) && $to_player->group < 2) {
-			$from_player->write('message`Error: '.$name.' is not a moderator.');
-		}
-		elseif(isset($to_player) && $to_player->group == 2) {
+		if(isset($to_player) && $to_player->group == 2) {
 			$to_player->group = 1;
 			$to_player->write('setGroup`1');
-			$from_player->write('message`'.$name.' has been demoted.');
 		}
 		global $port;
+		$safe_admin = escapeshellarg($from_player);
 		$safe_name = escapeshellarg($name);
-		exec("nohup php ".__DIR__."/commands/demod.php $port $safe_name > /dev/null &");
+		exec("nohup php ".__DIR__."/commands/demod.php $port $safe_name $safe_admin > /dev/null &");
 	}
 }
 


### PR DESCRIPTION
@jacob-grahn 

First of all, fixed the command paths.  As of now, the code on the master repo isn't searching in the /commands folder.  I am unable to promote or demote on Isabel at all.

Now, for the bulk of the changes.

The theory that's operating here is that I can pass the promoter as an entire player object from pr2_moderation.php to promote_to_moderator.php and demod.php through the shell arguments.  Then, the error messages use the caught exceptions already built into the command phps.  The caught exception function is expanded a bit in both demod and promote_to_moderator.php.  If nothing is caught, then the script continues to write a success message to the promoter (dubbed $admin) by doing ``$admin->write("message`$name has been promoted to a $type moderator!");``

The only problem I can think of is that the shell exec() wouldn't be able to figure out what the heck $admin->write means.  In that case, some globals would probably need to be added to both of the command phps.  We could also go the route of eliminating the shell commands altogether and making promote_to_moderator.php and demod.php functions instead.

At any rate, I doubt it's anything that will be too difficult to crack.  See db84d82 for some more details.
  