### PR TITLE
Removed extra htmlspecialchars validation

### DIFF
--- a/server/rooms/ChatRoom.php
+++ b/server/rooms/ChatRoom.php
@@ -48,22 +48,17 @@ class ChatRoom extends Room {
 	
 	
 	public function send_chat($message, $user_id) {
-		if (strpos($message, '`') === false) {
-			$chat_message = new ChatMessage($user_id, $message);
-			
-			array_push($this->chat_array, $chat_message);
-			
-			$this->chat_array[0] = NULL;
-			array_shift($this->chat_array);
-			
-			foreach($this->player_array as $player){
-				if(!$player->is_ignored_id($user_id)){
-					$player->socket->write($message);
-				}
+		$chat_message = new ChatMessage($user_id, $message);
+		
+		array_push($this->chat_array, $chat_message);
+		
+		$this->chat_array[0] = NULL;
+		array_shift($this->chat_array);
+		
+		foreach($this->player_array as $player){
+			if(!$player->is_ignored_id($user_id)){
+				$player->socket->write($message);
 			}
-		}
-		else {
-			$player->write('message`Error: Illegal character in message.');
 		}
 	}
 	


### PR DESCRIPTION
The validation would've caught every message and flagged it as containing an illegal character, since data is passed to send_chat as ``chat`playername`playergroup`message``.

I *think* I figured out how to pull without adding 10 million commits in one.  Here's hoping.