### PR TITLE
Add html prevention in exception message

### DIFF
--- a/http_server/www/bans/show_record.php
+++ b/http_server/www/bans/show_record.php
@@ -97,7 +97,7 @@ if($is_mod === true) {
 
 
 echo "<p>$html_mod_name banned $html_banned_name for $f_duration on $formatted_time.</p>
-		<p>Reason: $reason</p>
+		<p>Reason: " . strip_tags($reason, "<br/><br>") . "</p>
 		<p>This ban will expire on $expire_formatted_time.</p>
 		<p> --- </p>
 		<p>$html_record</p>

--- a/http_server/www/vault/kong_order_placed.php
+++ b/http_server/www/vault/kong_order_placed.php
@@ -126,7 +126,7 @@ function unlock_item( $db, $user_id, $guild_id, $server_id, $slug, $user_name, $
 	}
 
 	else {
-		throw new Exception( "Item not found: $slug" );
+		throw new Exception( "Item not found: " . strip_tags($slug, "<br/><br>") );
 	}
 
 	if( $command != '' ) {


### PR DESCRIPTION
An small fix on exception to only allow new line tags.
Edit: added another new line only allowed on show_record.php