### PR TITLE
Fix friends/ignored server check from 2012 update

### DIFF
--- a/http_server/www/get_user_list.php
+++ b/http_server/www/get_user_list.php
@@ -58,8 +58,8 @@ try {
 		$active_rank = $rank + $used_tokens;
 		$hats = count(explode(',', $row->hat_array)) - 1;
 		
-		if(strpos($status, 'Playing Platform Racing 2 on ') !== false){
-			$status = substr($status, 29);
+		if(strpos($status, 'Playing on ') !== false){
+			$status = substr($status, 11);
 		}
 		
 		if($num > 0){


### PR DESCRIPTION
Lines 61-63.

On user lists (friends, ignored), it used to say "Derron" or "Carina" before the status language was updated in 2012.  Now, it says "Playing on Derron", which cuts off the server name on most names.  This change will fix that.