### PR TITLE
Add action logging to more mod actions

### DIFF
--- a/http_server/www/ban_user.php
+++ b/http_server/www/ban_user.php
@@ -1,4 +1,5 @@
 <?php
+
 require_once('../fns/all_fns.php');
 
 $banned_name = find('banned_name', '');
@@ -13,6 +14,8 @@ $force_ip = find('force_ip');
 $safe_banned_name = addslashes($banned_name);
 $safe_reason = addslashes($reason);
 $safe_record = addslashes($record);
+
+$ip = get_ip();
 
 try{
 	$db = new DB();
@@ -155,7 +158,7 @@ try{
 	}
 	
 	//record the ban in the action log
-	$db->call('mod_action_insert', array($mod->user_id, "$html_mod_user_name banned $html_banned_name {ban_id: $safe_record, duration: $duration, account_ban: $safe_account_ban, ip_ban: $safe_ip_ban, expire_time: $expire_time, $html_reason}", 0, get_ip()));
+	$db->call('mod_action_insert', array($mod->user_id, "$html_mod_user_name banned $html_banned_name from $ip {ban_id: $safe_record, duration: $duration, account_ban: $safe_account_ban, ip_ban: $safe_ip_ban, expire_time: $expire_time, $html_reason}", $mod->user_id, $ip));
 	
 }
 

--- a/http_server/www/ban_user.php
+++ b/http_server/www/ban_user.php
@@ -144,6 +144,18 @@ try{
 		}
 	}
 	
+	//htmlspecialchars
+	$html_banned_name = htmlspecialchars($banned_name);
+	$html_mod_user_name = htmlspecialchars($mod_user_name);
+	if ($reason != '') {
+		$html_reason = "Reason: " . htmlspecialchars($reason);
+	}
+	else {
+		$html_reason = "no reason given";
+	}
+	
+	//record the ban in the action log
+	$db->call('mod_action_insert', array($mod->user_id, "$html_mod_user_name banned $html_banned_name {ban_id: $safe_record, duration: $duration, account_ban: $safe_account_ban, ip_ban: $safe_ip_ban, expire_time: $expire_time, $html_reason}", 0, get_ip()));
 	
 }
 

--- a/http_server/www/guild_delete.php
+++ b/http_server/www/guild_delete.php
@@ -2,6 +2,8 @@
 
 require_once( '../fns/all_fns.php' );
 
+$ip = get_ip();
+
 try {
 
 	//--- import data
@@ -12,12 +14,27 @@ try {
 	$db = new DB();
 
 
-	//--- check thier login
+	//--- check their login
 	$mod = check_moderator($db);
 
 
 	//--- edit guild in db
 	$db->call( 'guild_delete', array($guild_id), 'Could not delete the guild.' );
+	
+	
+	$power = $mod->power;
+	
+	
+	if ($power >= 2) {
+	
+		//htmlspecialchars
+		$html_name = htmlspecialchars($mod->name);
+		$html_guild_id = htmlspecialchars($guild_id);
+	
+		//record the deletion in the action log
+		$db->call('mod_action_insert', array($user_id, "$html_name deleted guild $html_guild_id from $ip.", $user_id, $ip));
+	
+	}
 
 
 	//--- tell it to the world

--- a/http_server/www/mod/archive_message.php
+++ b/http_server/www/mod/archive_message.php
@@ -5,6 +5,7 @@ require_once('../../fns/output_fns.php');
 
 $message_id = find('message_id');
 $safe_message_id = addslashes($message_id);
+$ip = get_ip();
 
 
 	//connect
@@ -21,6 +22,14 @@ $safe_message_id = addslashes($message_id);
 							LIMIT 1");
 	if(!$result) {
 		throw new Exception('Could not mark message as archived.');
+	}
+
+	if ($mod->power >= 2) {
+		//htmlspecialchars
+		$html_mod_name = htmlspecialchars($mod->name);
+		
+		//record the change
+		$db->call('mod_action_insert', array($mod->user_id, "$html_mod_name archived the report of PM $safe_message_id from $ip", $mod->user_id, $ip));
 	}
 	
 ?>

--- a/http_server/www/mod/ban_edit.php
+++ b/http_server/www/mod/ban_edit.php
@@ -6,6 +6,8 @@ require_once('../../fns/output_fns.php');
 $action = find('action', 'none');
 $ban_id = find('ban_id');
 
+$ip = get_ip();
+
 try {
     
     
@@ -49,7 +51,7 @@ try {
 	$db->query($query, 'ban_update', 'Could not update ban. query: ' . $query);
 	
 	//record the change
-	$db->call('mod_action_insert', array($mod->user_id, "$mod->name edited ban $ban_id {account_ban: $safe_account_ban, ip_ban: $safe_ip_ban, expire_time: $safe_expire_time, notes: $safe_notes}", 0, get_ip()));
+	$db->call('mod_action_insert', array($mod->user_id, "$mod->name edited ban $ban_id from $ip {account_ban: $safe_account_ban, ip_ban: $safe_ip_ban, expire_time: $safe_expire_time, notes: $safe_notes}", $mod->user_id, $ip));
 	
 	//redirect to the ban listing
 	header("Location: http://pr2hub.com/bans/show_record.php?ban_id=$ban_id");

--- a/http_server/www/mod/do_lift_ban.php
+++ b/http_server/www/mod/do_lift_ban.php
@@ -7,6 +7,7 @@ $ban_id = find('ban_id');
 $reason = find('reason');
 $safe_ban_id = addslashes($ban_id);
 $safe_reason = addslashes($reason . ' @' . date('M j, Y g:i A'));
+$ip = get_ip();
 
 try {
 
@@ -25,16 +26,6 @@ try {
 
 	$user_id = $mod->user_id;
 	$name = $mod->name;
-	
-	// htmlspecialchars
-	$html_name = htmlspecialchars($name);
-	$html_ban_id = htmlspecialchars($ban_id);
-	if ($reason != '') {
-		$html_reason = "Reason: " . htmlspecialchars($reason);
-	}
-	else {
-		$html_reason = "There was no reason given";
-	}
 
 	$safe_name = addslashes($name);
 
@@ -50,8 +41,18 @@ try {
 		throw new Exception('Could not lift ban');
 	}
 	
+	// htmlspecialchars
+	$html_name = htmlspecialchars($name);
+	$html_ban_id = htmlspecialchars($ban_id);
+	if ($reason != '') {
+		$html_reason = "Reason: " . htmlspecialchars($reason);
+	}
+	else {
+		$html_reason = "There was no reason given";
+	}
+	
 	//record the change
-	$db->call('mod_action_insert', array($mod->user_id, "$html_name lifted ban $html_ban_id. $html_reason.", 0, get_ip()));
+	$db->call('mod_action_insert', array($mod->user_id, "$html_name lifted ban $html_ban_id from $ip. $html_reason.", $mod->user_id, $ip));
 
 
 	//redirect to a page showing the lifted ban

--- a/http_server/www/mod/do_lift_ban.php
+++ b/http_server/www/mod/do_lift_ban.php
@@ -25,6 +25,16 @@ try {
 
 	$user_id = $mod->user_id;
 	$name = $mod->name;
+	
+	// htmlspecialchars
+	$html_name = htmlspecialchars($name);
+	$html_ban_id = htmlspecialchars($ban_id);
+	if ($reason != '') {
+		$html_reason = "Reason: " . htmlspecialchars($reason);
+	}
+	else {
+		$html_reason = "There was no reason given";
+	}
 
 	$safe_name = addslashes($name);
 
@@ -39,6 +49,9 @@ try {
 	if(!$result){
 		throw new Exception('Could not lift ban');
 	}
+	
+	//record the change
+	$db->call('mod_action_insert', array($mod->user_id, "$html_name lifted ban $html_ban_id. $html_reason.", 0, get_ip()));
 
 
 	//redirect to a page showing the lifted ban

--- a/http_server/www/remove_level.php
+++ b/http_server/www/remove_level.php
@@ -34,7 +34,7 @@ try{
 	$user_id = $mod->user_id;
 	
 	//record the change
-	$db->call('mod_action_insert', array($user_id, "$html_name unpublished level $html_level_id from $ip.", $user_id, $ip));
+	$db->call('mod_action_insert', array($user_id, "$html_name unpublished level $html_level_id from $ip", $user_id, $ip));
 	
 }
 

--- a/http_server/www/remove_level.php
+++ b/http_server/www/remove_level.php
@@ -4,7 +4,6 @@ require_once('../fns/all_fns.php');
 
 $level_id = find('level_id', 'none');
 $ip = get_ip();
-$user_id = $mod->user_id;
 
 try{	
 	//error check
@@ -25,12 +24,14 @@ try{
 	//unpublish the level
 	$db->call('level_unpublish', array($level_id));
 	
+	//tell it to the world
+	echo 'message=This level has been removed successfully. It may take up to 60 seconds for this change to take effect.';
+	
 	//htmlspecialchars
 	$html_name = htmlspecialchars($mod->name);
 	$html_level_id = htmlspecialchars($level_id);
 	
-	//tell it to the world
-	echo 'message=This level has been removed successfully. It may take up to 60 seconds for this change to take effect.';
+	$user_id = $mod->user_id;
 	
 	//record the change
 	$db->call('mod_action_insert', array($user_id, "$html_name unpublished level $html_level_id from $ip.", $user_id, $ip));

--- a/http_server/www/remove_level.php
+++ b/http_server/www/remove_level.php
@@ -29,11 +29,12 @@ try{
 	$html_name = htmlspecialchars($mod->name);
 	$html_level_id = htmlspecialchars($level_id);
 	
+	//tell it to the world
+	echo 'message=This level has been removed successfully. It may take up to 60 seconds for this change to take effect.';
+	
 	//record the change
 	$db->call('mod_action_insert', array($user_id, "$html_name unpublished level $html_level_id from $ip.", $user_id, $ip));
 	
-	//tell it to the world
-	echo 'message=This level has been removed successfully. It may take up to 60 seconds for this change to take effect.';
 }
 
 catch(Exception $e){

--- a/http_server/www/remove_level.php
+++ b/http_server/www/remove_level.php
@@ -3,6 +3,8 @@
 require_once('../fns/all_fns.php');
 
 $level_id = find('level_id', 'none');
+$ip = get_ip();
+$user_id = $mod->user_id;
 
 try{	
 	//error check
@@ -22,6 +24,13 @@ try{
 	
 	//unpublish the level
 	$db->call('level_unpublish', array($level_id));
+	
+	//htmlspecialchars
+	$html_name = htmlspecialchars($mod->name);
+	$html_level_id = htmlspecialchars($level_id);
+	
+	//record the change
+	$db->call('mod_action_insert', array($user_id, "$html_name unpublished level $html_level_id from $ip.", $user_id, $ip));
 	
 	//tell it to the world
 	echo 'message=This level has been removed successfully. It may take up to 60 seconds for this change to take effect.';

--- a/server/fns/demod.php
+++ b/server/fns/demod.php
@@ -46,6 +46,17 @@ function demote_mod($port, $user_name, $admin, $demoted_player) {
 		if(!$result) {
 			throw new Exception("Could not demote $user_name due to a database error.");
 		}
+		
+		//htmlspecialchars
+		$html_admin_name = htmlspecialchars($admin->name);
+		$html_demoted_name = htmlspecialchars($user_name);
+		$html_port = htmlspecialchars($port);
+		
+		$ip = $admin->ip;
+		
+		// log action in action log
+		$db->call('mod_action_insert', array($admin->user_id, "$html_admin_name demoted $html_demoted_name from $ip on port $html_port", $admin->user_id, $ip));
+		
 	}
 
 	catch(Exception $e){

--- a/server/fns/promote_to_moderator.php
+++ b/server/fns/promote_to_moderator.php
@@ -139,8 +139,10 @@ function promote_mod($port, $name, $type, $admin, $promoted_player) {
 			$html_type = htmlspecialchars($type);
 			$html_port = htmlspecialchars($port);
 			
+			$ip = $admin->ip;
+			
 			// log action in action log
-			$db->call('mod_action_insert', array($mod->user_id, "$html_admin_name promoted $html_promoted_name to a $html_type moderator from $ip on port $html_port", $admin->user_id, $ip));
+			$db->call('mod_action_insert', array($admin->user_id, "$html_admin_name promoted $html_promoted_name to a $html_type moderator from $ip on port $html_port", $admin->user_id, $ip));
 			
 		}
 

--- a/server/fns/promote_to_moderator.php
+++ b/server/fns/promote_to_moderator.php
@@ -132,6 +132,16 @@ function promote_mod($port, $name, $type, $admin, $promoted_player) {
 			if(!$result) {
 				throw new Exception('Could not set limits on the new moderator\'s power.');
 			}
+			
+			//htmlspecialchars
+			$html_admin_name = htmlspecialchars($admin->name);
+			$html_promoted_name = htmlspecialchars($promoted_player->name);
+			$html_type = htmlspecialchars($type);
+			$html_port = htmlspecialchars($port);
+			
+			// log action in action log
+			$db->call('mod_action_insert', array($mod->user_id, "$html_admin_name promoted $html_promoted_name to a $html_type moderator from $ip on port $html_port", $admin->user_id, $ip));
+			
 		}
 
 		catch(Exception $e){


### PR DESCRIPTION
Added action logging support for:
 - Deleting guilds
 - Lifting bans
 - Banning
 - Unpublishing levels
 - Deleting guilds
 - Archiving PM reports

Check my code and make sure it all works with `$db->call`, whether it's on the http server or the actual PR2 servers.