### PR TITLE
Key changes to first artifact finder mechanic

### DIFF
--- a/server/fns/artifact_first_check.php
+++ b/server/fns/artifact_first_check.php
@@ -9,14 +9,38 @@ function artifact_first_check($port, $player) {
 	$safe_user_name = htmlspecialchars($player->name);
 
 	try {
+		
 		$first_finder = $db->grab( 'first_finder', 'artifact_find', array($user_id) );
 
 		if( $first_finder == $user_id ) {
-			award_parts( $db, $user_id, 'head', [27] );
-			award_parts( $db, $user_id, 'body', [21] );
-			award_parts( $db, $user_id, 'feet', [28] );
+			
+			/* What are we gonna tell the player when they win?
+			How about display a prize window with the bubble body and the name "Bubble Set" */
+			
+			// make a prize array for the game to show the user
+			$artifact_first_prize_popup = json_encode(array(
+				"type" => "body",
+				"id" => 21,
+				"name" => "Bubble Set",
+				"desc" => "For finding the artifact first, you earned your very own bubble set!",
+				"universal" => true
+				));
+			
+			// give all parts of the bubble set using the gain_part function from Player.php
+			$player->gain_part( "head", 27, true );
+			$player->gain_part( "body", 21, true );
+			$player->gain_part( "feet", 28, true );
+			
+			// tell the world
 			echo "Awarded bubble set to $safe_user_name for finding the artifact first.";
-			$player->write('message`The most humble of congratulations to you for finding the artifact first! To commemorate this momentous occasion, you\'ve been awarded with your very own bubble set.<br><br>Thanks for playing Platform Racing 2!<br>- Jiggmin');
+			$player->write( 'winPrize`' . $artifact_first_prize_popup );
+			
+			// pm the user (finishing touch!)
+			$artifact_first_pm = 'Dear '.$safe_user_name.',\r\rI\'d like to sincerely congratulate you for finding the artifact first! To commemorate this momentous occasion, you\'ve been awarded with your very own bubble set.\r\rThanks for playing Platform Racing 2!\r\r - Jiggmin';
+			
+			$db->call( 'message_insert', array($user_id, 1, $artifact_first_pm, '0') );
+
+			}
 			
 		}
 	}
@@ -27,51 +51,6 @@ function artifact_first_check($port, $player) {
 		return false;
 	}
 
-}
-
-
-//--- award hats ----------------------------------
-function award_parts($db, $user_id, $type, $part_ids, $ensure=true) {
-
-	if($type == 'hat') {
-		$field = 'hat_array';
-	}
-	else if($type == 'head') {
-		$field = 'head_array';
-	}
-	else if($type == 'body') {
-		$field = 'body_array';
-	}
-	else if($type == 'feet') {
-		$field = 'feet_array';
-	}
-	else {
-		throw new Exception('Unknown type');
-	}
-
-	$array_str = $db->grab($field, 'pr2_select', array($user_id));
-
-	$array = explode(',', $array_str);
-
-	foreach($part_ids as $part_id) {
-		if( $ensure ) {
-			$db->call( 'part_awards_insert', array( $user_id, $type, $part_id, MYSQLI_ASYNC ) );
-		}
-		$index = array_search($part_id, $array);
-		if($index === false) {
-			$array[] = $part_id;
-		}
-	}
-
-	$new_array_str = join(',', $array);
-
-	if($new_array_str != $array_str) {
-		$db->call('pr2_update_part_array', array($user_id, $type, $new_array_str), MYSQLI_ASYNC);
-		return true;
-	}
-	else {
-		return false;
-	}
 }
 
 ?>

--- a/server/fns/artifact_first_check.php
+++ b/server/fns/artifact_first_check.php
@@ -38,10 +38,7 @@ function artifact_first_check($port, $player) {
 			// pm the user (finishing touch!)
 			$artifact_first_pm = 'Dear '.$safe_user_name.',\r\rI\'d like to sincerely congratulate you for finding the artifact first! To commemorate this momentous occasion, you\'ve been awarded with your very own bubble set.\r\rThanks for playing Platform Racing 2!\r\r - Jiggmin';
 			
-			$db->call( 'message_insert', array($user_id, 1, $artifact_first_pm, '0') );
-
-			}
-			
+			$db->call( 'message_insert', array($user_id, 1, $artifact_first_pm, '0') );			
 		}
 	}
 


### PR DESCRIPTION
This pull contains some key changes to the first artifact finder mechanic.  The script will now:

 - Echo a prize box that says "Bubble Set" and has the bubble body as an icon
 - There's too much going on when the user finds the artifact first.  Instead of popping up a congratulatory message, PM it to the user (check my code on line 45 to make sure I'm using `$db->call` correctly)
 - Award the prize via gain_part() (taken from Player.php) and auto-set the prize upon return to the lobby

Of course, check my code, but this is a lot simpler than the code was before since it uses functions that already exist.  Plus, it actually works. :)

LMK if/when you merge this code and get it running on Isabel so I can test if it works for awarding it to the first finder.