### PR TITLE
Fix welcome/winner PMs, which display the literal text \r instead of a new line

### DIFF
--- a/http_server/www/login.php
+++ b/http_server/www/login.php
@@ -145,7 +145,15 @@ try {
 		$db->call('pr2_insert', array($user_id));
 
 		//--- send them a welcome pm
-		$welcome_message = 'Welcome to Platform Racing 2, '.$user_name.'!\r\r<a href="https://grahn.io" target="_blank"><u><font color="#0000FF">Click here</font></u></a> to read about the latest Platform Racing news on my blog.\r\rIf you have any questions or comments, send me an email at <a href="mailto:jacob@grahn.io?subject=Questions or Comments about PR2" target="_blank"><u><font color="#0000FF">jacob@grahn.io</font></u></a>.\r\rThanks for playing, I hope you enjoy.\r\r- Jacob';
+		$welcome_message = 'Welcome to Platform Racing 2, '.$user_name.'!
+
+<a href="https://grahn.io" target="_blank"><u><font color="#0000FF">Click here</font></u></a> to read about the latest Platform Racing news on my blog.
+
+If you have any questions or comments, send me an email at <a href="mailto:jacob@grahn.io?subject=Questions or Comments about PR2" target="_blank"><u><font color="#0000FF">jacob@grahn.io</font></u></a>.
+
+Thanks for playing, I hope you enjoy.
+
+- Jacob';
 		
 		$db->call('message_insert', array($user_id, 1, $welcome_message, '0'));
 

--- a/server/fns/artifact_first_check.php
+++ b/server/fns/artifact_first_check.php
@@ -19,8 +19,8 @@ function artifact_first_check($port, $player) {
 			
 			// make a prize array for the game to show the user
 			$artifact_first_prize_popup = json_encode(array(
-				"type" => "body",
-				"id" => 21,
+				"type" => "eHat",
+				"id" => 14,
 				"name" => "Bubble Set",
 				"desc" => "For finding the artifact first, you earned your very own bubble set!",
 				"universal" => true

--- a/server/fns/artifact_first_check.php
+++ b/server/fns/artifact_first_check.php
@@ -36,7 +36,13 @@ function artifact_first_check($port, $player) {
 			$player->write( 'winPrize`' . $artifact_first_prize_popup );
 			
 			// pm the user (finishing touch!)
-			$artifact_first_pm = 'Dear '.$safe_user_name.',\r\rI\'d like to sincerely congratulate you for finding the artifact first! To commemorate this momentous occasion, you\'ve been awarded with your very own bubble set.\r\rThanks for playing Platform Racing 2!\r\r - Jiggmin';
+			$artifact_first_pm = 'Dear '.$safe_user_name.',
+
+I\'d like to sincerely congratulate you for finding the artifact first! To commemorate this momentous occasion, you\'ve been awarded with your very own bubble set.
+
+Thanks for playing Platform Racing 2!
+
+- Jiggmin';
 			
 			$db->call( 'message_insert', array($user_id, 1, $artifact_first_pm, '0') );			
 		}


### PR DESCRIPTION
Changed \r to real new lines.

Couple of questions @jacob-grahn:
 - I assume the default color for each part is set in the client?  If not, could we set the bubble body to black?  It sort of blends in with the prize popup.
 - Will this award the bubble set even if the first finder has it already?  Or does gain_part check for the user having the part first?

Other than that, everything is working perfectly!