### PR TITLE
Added protection against html parsing in client

### DIFF
--- a/http_server/www/get_player_info_2.php
+++ b/http_server/www/get_player_info_2.php
@@ -1,6 +1,6 @@
 <?php
 
-header("Content-type: text/plain");
+header("Content-type: text/plain;charset=UTF-8");
 
 require_once('../fns/all_fns.php');
 
@@ -13,7 +13,7 @@ try {
 
 	$db = new DB();
 
-	//--- check thier login
+	//--- check their login
 	try {
 		$user_id = token_login($db);
 	}
@@ -31,7 +31,7 @@ try {
 	if( $target->guild != 0 ) {
 		try {
 			$guild = $db->grab_row( 'guild_select', array( $target->guild ) );
-			$guild_name = $guild->guild_name;
+			$guild_name = htmlspecialchars($guild->guild_name);
 		}
 		catch (Exception $e) {
 			$guild_name = '';

--- a/http_server/www/guilds_top.php
+++ b/http_server/www/guilds_top.php
@@ -1,8 +1,6 @@
 <?php
 
-if (!headers_sent()){
-	header("Content-Type: text/plain;charset=UTF-8");	
-}
+header("Content-Type: text/plain;charset=UTF-8");
 
 require_once( '../fns/all_fns.php' );
 require_once( '../fns/pr2_fns.php' );

--- a/http_server/www/guilds_top.php
+++ b/http_server/www/guilds_top.php
@@ -1,7 +1,7 @@
 <?php
 
 if (!headers_sent()){
-	header("Content-Type: text/plain");	
+	header("Content-Type: text/plain;charset=UTF-8");	
 }
 
 require_once( '../fns/all_fns.php' );
@@ -29,8 +29,10 @@ try {
 	
 	
 	//--- get active member count guild by guild
+	//--- also disable html parsing
 	foreach( $guilds as $guild ) {
 		$guild->active_count = guild_count_active( $db, $guild->guild_id );
+		$guild->guild_name = htmlspecialchars($guild->guild_name);
 	}
 	
 	


### PR DESCRIPTION
This fix was relatively simple compared to what I was expecting. I was able to simply add a line that converts `$guild->guild_name` to `htmlspecialchars($guild->guild_name)`.  I also made sure the file sends characters in UTF-8 to prevent encoding errors.

Affected lines: 4, 35