### PR TITLE
Fix admin tools, add action logging for more mod actions

### DIFF
--- a/http_server/www/ban_user.php
+++ b/http_server/www/ban_user.php
@@ -144,6 +144,17 @@ try{
 		}
 	}
 	
+	//action log
+	if ($reason != '') {
+		$reason = "reason: " . $reason;
+	}
+	else {
+		$reason = "no reason given";
+	}
+	$ip = $mod->ip; // get mod's ip
+	
+	//record the ban in the action log
+	$db->call('mod_action_insert', array($mod->user_id, "$mod_user_name banned $banned_name from $ip {ban_id: $safe_record, duration: $duration, account_ban: $safe_account_ban, ip_ban: $safe_ip_ban, expire_time: $expire_time, reason: $html_reason}", 0, $ip));
 	
 }
 

--- a/http_server/www/guild_delete.php
+++ b/http_server/www/guild_delete.php
@@ -12,12 +12,24 @@ try {
 	$db = new DB();
 
 
-	//--- check thier login
+	//--- check their login
 	$mod = check_moderator($db);
-
+	
+	//--- check if the guild exists
+	$guild = $db->grab_row( 'guild_select', array($guild_id), 'Could not find a guild with that id.' );
 
 	//--- edit guild in db
 	$db->call( 'guild_delete', array($guild_id), 'Could not delete the guild.' );
+	
+	//htmlspecialchars
+	$mod_name = $mod->name;
+	$ip = $mod->ip;
+	$guild_name = $guild->name;
+	$guild_note = $guild->note;
+	$guild_owner = $guild->owner_id;
+	
+	//record the deletion in the action log
+	$db->call('mod_action_insert', array($user_id, "$mod_name deleted guild $guild_id from $ip {name: $guild_name, note: $guild_note, owner_id: $guild_owner}", $user_id, $ip));
 
 
 	//--- tell it to the world

--- a/http_server/www/mod/archive_message.php
+++ b/http_server/www/mod/archive_message.php
@@ -22,5 +22,13 @@ $safe_message_id = addslashes($message_id);
 	if(!$result) {
 		throw new Exception('Could not mark message as archived.');
 	}
+
+	//action log
+	$name = $mod->name;
+	$ip = $mod->ip;
+		
+		//record the change
+		$db->call('mod_action_insert', array($mod->user_id, "$name archived the report of PM $safe_message_id from $ip", $mod->user_id, $ip));
+	}
 	
 ?>

--- a/http_server/www/mod/do_lift_ban.php
+++ b/http_server/www/mod/do_lift_ban.php
@@ -40,9 +40,19 @@ try {
 		throw new Exception('Could not lift ban');
 	}
 
+	if ($reason != '') {
+		$reason = "Reason: " . $reason;
+	}
+	else {
+		$reason = "There was no reason given";
+	}
+	
+	//record the change
+	$db->call('mod_action_insert', array($user_id, "$name lifted ban $ban_id. $reason.", 0, get_ip()));
+
 
 	//redirect to a page showing the lifted ban
-	header("Location: ../bans/show_record.php?ban_id=$ban_id") ;
+	header("Location: show_record.php?ban_id=$ban_id") ;
 }
 
 catch(Exception $e){

--- a/http_server/www/mod/guild_deep_info.php
+++ b/http_server/www/mod/guild_deep_info.php
@@ -3,7 +3,7 @@
 require_once('../../fns/all_fns.php');
 require_once('../../fns/output_fns.php');
 
-$guild_id = find('id', 0);
+$guild_id = find('guild_id', 0);
 
 output_header('Guild Deep Info');
 
@@ -17,13 +17,17 @@ try{
 	//make sure you're an admin
 	$mod = check_moderator($db, false, 3);
 	
+	if ($guild_id == 0) {
+		$guild_id = '';
+	}
+	
 	
 	echo '<form name="input" action="" method="get">';
 	echo 'Guild ID: <input type="text" name="guild_id" value="'.htmlspecialchars($guild_id).'"><br>';
 	if( $guild_id != '' ) {
 		try {
-			$guild = $db->grab_row( 'guild_select', array($guild_id) );
-			$members = $db->grab_row( 'guild_select_members', array($guild->guild_id), '', true );
+			$guild = $db->grab_row( 'guild_select', array($guild_id), 'Could not find a guild with that id.' );
+			$members = $db->call( 'guild_select_members', array($guild_id) );
 			echo "Guild ID: $guild->guild_id <br/>";
 			output_object( $guild );
 			output_objects( $members );

--- a/http_server/www/mod/update_account.php
+++ b/http_server/www/mod/update_account.php
@@ -221,7 +221,7 @@ Rabbit = 39</pre>';
 
 
 function update($db) {
-    $guild_id = (int) find('id');
+    $guild_id = (int) find('guild');
     $user_id = (int) find('id');
 
     $user = $db->grab_row('user_select', array($user_id));

--- a/http_server/www/mod/update_guild.php
+++ b/http_server/www/mod/update_guild.php
@@ -44,7 +44,6 @@ function output_form($db, $guild_id) {
     echo '<form name="input" action="update_guild.php" method="get">';
     
 	$guild = $db->grab_row('guild_select', array($guild_id));
-	$members = $db->grab_row('guild_select_members', array($guild->guild_id));
 	echo "guild_id: $guild->guild_id <br>---<br>";
 
 	
@@ -57,7 +56,7 @@ function output_form($db, $guild_id) {
 	echo '<input type="hidden" name="guild_id" value="'.$guild->guild_id.'">';
     
     echo '<br/>';
-    echo '<input type="submit" value="Submit">';
+    echo '<input type="submit" value="Submit">&nbsp;(no confirmation!)';
     echo '</form>';
     
     echo '<br>';
@@ -76,6 +75,7 @@ else {
 }
 
 if (!empty($_GET['recount_members'])) {
+	$members = $db->call('guild_select_members', array($guild->guild_id));
 	$member_count = mysqli_num_rows($members);
 }
 else {
@@ -88,9 +88,15 @@ function update($db) {
     
     $guild = $db->grab_row('guild_select', array($guild_id));
 
-    $db->call( 'guild_update', array($guild_id, find('guild_name'), $emblem, find('note'), $owner_id, $member_count), 'A guild already exists with that name.' );
+    $db->call( 'guild_update', array(
+	    $guild_id,
+	    find('guild_name'),
+	    $emblem,
+	    find('note'),
+	    $owner_id,
+	    $member_count), 'A guild already exists with that name.' );
     
-    header("Location: http://pr2hub.com/mod/guild_deep_info.php?id=" . urlencode(find('guild_id')));
+    header("Location: http://pr2hub.com/mod/guild_deep_info.php?guild_id=" . urlencode(find('guild_id')));
     /*echo('updated! <br>---<br>');
     output_form($db, $user_id);*/
 }

--- a/http_server/www/remove_level.php
+++ b/http_server/www/remove_level.php
@@ -3,7 +3,6 @@
 require_once('../fns/all_fns.php');
 
 $level_id = find('level_id', 'none');
-$ip = get_ip();
 
 try{	
 	//error check
@@ -22,7 +21,11 @@ try{
 	}
 	
 	//check for the level's information
-	$level = $db->call('pr2_levels', array($level_id));
+	$level = $db->grab_row( 'level_select', array($level_id) );
+	$l_title = $level->title;
+	$l_creator = $level->user_id;
+	$l_note = $level->note;
+	
 	
 	//unpublish the level
 	$db->call('level_unpublish', array($level_id));
@@ -33,11 +36,10 @@ try{
 	//action log
 	$name = $mod->name;
 	$user_id = $mod->user_id;
-	$level_name = $level->title;
-	$level_desc = $level->note;
+	$ip = $mod->ip;
 	
 	//record the change
-	$db->call('mod_action_insert', array($user_id, "$name unpublished level $level_id from $ip {level_name: $level_name, level_note: $level_desc, creator: ????????????????}", $user_id, $ip));
+	$db->call('mod_action_insert', array($user_id, "$name unpublished level $level_id from $ip {level_title: $l_title, creator: $l_creator, level_note: $l_note}", $user_id, $ip));
 	
 }
 

--- a/http_server/www/remove_level.php
+++ b/http_server/www/remove_level.php
@@ -3,6 +3,7 @@
 require_once('../fns/all_fns.php');
 
 $level_id = find('level_id', 'none');
+$ip = get_ip();
 
 try{	
 	//error check
@@ -20,11 +21,24 @@ try{
 		throw new Exception('You can not unpublish levels.');
 	}
 	
+	//check for the level's information
+	$level = $db->call('pr2_levels', array($level_id));
+	
 	//unpublish the level
 	$db->call('level_unpublish', array($level_id));
 	
 	//tell it to the world
 	echo 'message=This level has been removed successfully. It may take up to 60 seconds for this change to take effect.';
+	
+	//action log
+	$name = $mod->name;
+	$user_id = $mod->user_id;
+	$level_name = $level->title;
+	$level_desc = $level->note;
+	
+	//record the change
+	$db->call('mod_action_insert', array($user_id, "$name unpublished level $level_id from $ip {level_name: $level_name, level_note: $level_desc, creator: ????????????????}", $user_id, $ip));
+	
 }
 
 catch(Exception $e){

--- a/server/fns/demod.php
+++ b/server/fns/demod.php
@@ -46,6 +46,14 @@ function demote_mod($port, $user_name, $admin, $demoted_player) {
 		if(!$result) {
 			throw new Exception("Could not demote $user_name due to a database error.");
 		}
+		
+		//action log
+		$admin_name = $admin->name;
+		$ip = $admin->ip;
+		
+		// log action in action log
+		$db->call('mod_action_insert', array($admin->user_id, "$admin_name demoted $user_name from $ip on port $port", $admin->user_id, $ip));
+		
 	}
 
 	catch(Exception $e){

--- a/server/fns/promote_to_moderator.php
+++ b/server/fns/promote_to_moderator.php
@@ -1,13 +1,9 @@
 <?php
-
 require_once(__DIR__ . '/db_fns.php');
-
 function promote_mod($port, $name, $type, $admin, $promoted_player) {
 	global $db;
-
 	// boolean var for use in if statement @end
 	$caught_exception = false;
-
 	// if the user isn't an admin on the server, kill the function (2nd line of defense)
 	if($admin->group != 3) {
 		$caught_exception = true;
@@ -15,7 +11,6 @@ function promote_mod($port, $name, $type, $admin, $promoted_player) {
 		$admin->write("message`Error: You lack the power to promote $name to a $type moderator.");
 		return false;
 	}
-
 	// define variables needed
 	$user_id = name_to_id($db, $name);
 	$safe_admin_id = addslashes($admin->user_id);
@@ -23,14 +18,12 @@ function promote_mod($port, $name, $type, $admin, $promoted_player) {
 	$safe_type = addslashes($type);
 	$safe_time = addslashes(time());
 	$safe_min_time = addslashes(time()-(60*60*6));
-
 	// get info about the person promoting
 	$admin_result = $db->query("SELECT *
 									FROM users
 									WHERE user_id = '$safe_admin_id'
 									LIMIT 0,1");
 	$admin_row = $admin_result->fetch_object();
-
 	//check for proper permission in the db (3rd + final line of defense before promotion)
 	if($admin_row->power != 3) {
 		$caught_exception = true;
@@ -38,14 +31,12 @@ function promote_mod($port, $name, $type, $admin, $promoted_player) {
 		$admin->write("message`Error: You lack the power to promote $name to a $type moderator.");
 		return false;
 	}
-
 	// get info about the person being promoted
 	$user_result = $db->query("SELECT *
 									FROM users
 									WHERE user_id = '$safe_user_id'
 									LIMIT 0,1");
 	$user_row = $user_result->fetch_object();
-
 	// if the person being promoted is a guest, end the function
 	if($user_row->power < 1) {
 		$caught_exception = true;
@@ -53,7 +44,6 @@ function promote_mod($port, $name, $type, $admin, $promoted_player) {
 		$admin->write("message`Error: Guests can\'t be promoted to moderators.");
 		return false;
 	}
-
 	// if the person being promoted doesn't exist, end the function
 	if(count($user_row) < 1) {
 		$caught_exception = true;
@@ -61,14 +51,10 @@ function promote_mod($port, $name, $type, $admin, $promoted_player) {
 		$admin->write("message`Error: $name doesn\'t exist.");
 		return false;
 	}
-
 	// now that we've determined that the user is able to do what they're trying to do, let's finish
-
 	// if type is trial or permanent, do promotion things in the db
 	if ($type == 'trial' || $type == 'permanent') {
-
 		try {
-
 			//throttle mod promotions
 			$result = $db->query("SELECT COUNT(*) as recent_promotion_count
 											FROM promotion_log
@@ -77,12 +63,10 @@ function promote_mod($port, $name, $type, $admin, $promoted_player) {
 			if(!$result) {
 				throw new Exception('Could not check for recent promotions.');
 			}
-
 			$row = $result->fetch_object();
 			if($row->recent_promotion_count > 0) {
 				throw new Exception('Someone has already been promoted to a moderator recently. Wait a bit before trying to promote again.');
 			}
-
 			//log the power change
 			$result = $db->query("INSERT INTO promotion_log
 										 	SET message = 'user_id: $safe_user_id has been promoted to $safe_type moderator',
@@ -91,7 +75,6 @@ function promote_mod($port, $name, $type, $admin, $promoted_player) {
 			if(!$result) {
 				throw new Exception('Could not record the promotion in the database.');
 			}
-
 			//do the power change
 			$result = $db->query("update users
 											set power = 2
@@ -99,7 +82,6 @@ function promote_mod($port, $name, $type, $admin, $promoted_player) {
 			if(!$result){
 				throw new Exception("Could not promote $name to a $type moderator.");
 			}
-
 			//set power limits
 			if($type == 'trial') {
 				$max_ban = 60 * 60 * 24;
@@ -111,11 +93,9 @@ function promote_mod($port, $name, $type, $admin, $promoted_player) {
 				$bans_per_hour = 101;
 				$can_unpublish_level = 1;
 			}
-
 			$safe_max_ban = $db->real_escape_string($max_ban);
 			$safe_bans_per_hour = $db->real_escape_string($bans_per_hour);
 			$safe_can_unpublish_level = $db->real_escape_string($can_unpublish_level);
-
 			$result = $db->query("INSERT INTO mod_power
 											SET user_id = '$safe_user_id',
 												max_ban = '$safe_max_ban',
@@ -132,8 +112,17 @@ function promote_mod($port, $name, $type, $admin, $promoted_player) {
 			if(!$result) {
 				throw new Exception('Could not set limits on the new moderator\'s power.');
 			}
+			
+			//action log
+			$admin_name = $admin->name;
+			$promoted_name = $promoted_player->name;
+			
+			$ip = $admin->ip;
+			
+			// log action in action log
+			$db->call('mod_action_insert', array($admin->user_id, "$admin_name promoted $promoted_name to a $type moderator from $ip on port $port", $admin->user_id, $ip));
+			
 		}
-
 		catch(Exception $e){
 			$caught_exception = true;
 			$promoted_player = NULL;
@@ -141,13 +130,9 @@ function promote_mod($port, $name, $type, $admin, $promoted_player) {
 			$admin->write('message`Error: '.$e->getMessage());
 			return false;
 		}
-
 	} // end if trial/permanent
-
 	elseif ($type == 'temporary') {
-
 		try {
-
 			//check for proper permission in the db (useless due to identical check on line 36)
 			$result = $db->query("SELECT *
 											FROM users
@@ -157,9 +142,7 @@ function promote_mod($port, $name, $type, $admin, $promoted_player) {
 			if($row->power != 3) {
 				throw new Exception("You lack the power to promote $name to a $type moderator.");
 			}
-
 		}
-
 		catch(Exception $e){
 			$caught_exception = true;
 			$promoted_player = NULL;
@@ -167,9 +150,7 @@ function promote_mod($port, $name, $type, $admin, $promoted_player) {
 			$admin->write('message`Error: '.$e->getMessage());
 			return false;
 		}
-
 	} // end if temp
-
 	// if all of that was valid and error-less, carry out the client-side changes
 	if (!$caught_exception) {
 		if(isset($promoted_player) && $promoted_player->group != 0 && $type == 'temporary'){
@@ -183,8 +164,5 @@ function promote_mod($port, $name, $type, $admin, $promoted_player) {
 		$admin->write("message`$name has been promoted to a $type moderator!");
 		return true;
 	}
-
-
 }
-
 ?>


### PR DESCRIPTION
Adds action logging for these mod actions:
 - Deleting guilds
 - Lifting bans
 - Banning
 - Unpublishing levels
 - Deleting guilds
 - Archiving PM reports

This pull is a fix for #58. Please make sure it accomplishes what it set out to accomplish.

Also, I provided some fixes for the admin guild/player update/viewing tools; However, the database functions need to be updated in order to be fully functional.  See #97 for more details.