### PR TITLE
Definitively fix emblem deletion, more housekeeping

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,15 @@
 # Platform Racing 2 Server
 
+## Guidelines for Contributors
+
+Welcome to the PR2 GitHub repo!
+
+All contributions are welcome; However, please keep these things in mind when contributing:
+- Only edit things if you know exactly what they do and what you're doing.
+- If you want to edit something but don't exactly know what to do, post an issue and someone will assist you.
+- When submitting a pull request, leave a summary of your changes in the title/description.
+- I'll check all of the code before it goes in, but make sure it won't throw a syntax error by checking it [here](https://phpcodechecker.com/).
+
 ## Contributors
 - aaaaaa123456789
 - Antonhs30000

--- a/http_server/www/mod/ban_edit.php
+++ b/http_server/www/mod/ban_edit.php
@@ -83,11 +83,15 @@ catch(Exception $e){
 	output_footer();
 }
 
-    // checked box check needs to go outside the output_form function
+
+function output_form($ban) {
+
+    // define checked box variables
     $checked_box = 'checked="checked"';
     $ip_checked = '';
     $acc_checked = '';
-	    
+
+    // check for ban types
     if ($ban->ip_ban === 1) {
     	$ip_checked = $checked_box;
     }
@@ -95,15 +99,14 @@ catch(Exception $e){
         $acc_checked = $checked_box;
     }
 
-
-function output_form($ban) {
+    // write the data
     echo "
     <form>
 	<input type='hidden' value='edit' name='action'>
 	<input type='hidden' value='$ban->ban_id' name='ban_id'>
 	<p>Expire Date <input type='text' value='$ban->expire_datetime' name='expire_time'></p>
-	<p>Ip Ban <input type='checkbox' $ip_checked name='ip_ban'></p>
-	<p>Account Ban <input type='checkbox' $acc_checked name='account_ban'></p>
+	<p>IP Ban <input type='checkbox' name='ip_ban' $ip_checked></p>
+	<p>Account Ban <input type='checkbox' name='account_ban' $acc_checked></p>
 	<p>Notes <textarea rows='4' cols='50' name='notes'>$ban->notes</textarea>
 	<p><input type='submit' value='submit'></p>
     </form>";

--- a/http_server/www/mod/ban_edit.php
+++ b/http_server/www/mod/ban_edit.php
@@ -71,7 +71,7 @@ try {
 	$db->call('mod_action_insert', array($mod->user_id, "$mod->name edited ban $ban_id from $ip {account_ban: $is_account_ban, ip_ban: $is_ip_ban, expire_time: $safe_expire_time, notes: $disp_notes}", 0, $ip));
 	
 	//redirect to the ban listing
-	header("Location: http://pr2hub.com/bans/show_record.php?ban_id=$ban_id");
+	header("Location: https://pr2hub.com/bans/show_record.php?ban_id=$ban_id");
     }
     
     

--- a/http_server/www/mod/ban_edit.php
+++ b/http_server/www/mod/ban_edit.php
@@ -58,8 +58,17 @@ try {
 		$is_ip_ban = 'yes';
 	}
 	
+	// check for ban notes
+	$notes = trim(find('notes'));
+	if(empty($notes) || $notes == '') {
+		$disp_notes = 'no notes';
+	}
+	
+	// get ip
+	$ip = get_ip();
+	
 	//record the change
-	$db->call('mod_action_insert', array($mod->user_id, "$mod->name edited ban $ban_id {account_ban: $is_account_ban, ip_ban: $is_ip_ban, expire_time: $safe_expire_time, notes: $safe_notes}", 0, get_ip()));
+	$db->call('mod_action_insert', array($mod->user_id, "$mod->name edited ban $ban_id from $ip {account_ban: $is_account_ban, ip_ban: $is_ip_ban, expire_time: $safe_expire_time, notes: $disp_notes}", 0, $ip));
 	
 	//redirect to the ban listing
 	header("Location: http://pr2hub.com/bans/show_record.php?ban_id=$ban_id");

--- a/http_server/www/mod/do_lift_ban.php
+++ b/http_server/www/mod/do_lift_ban.php
@@ -47,12 +47,14 @@ try {
 		$disp_reason = "There was no reason given";
 	}
 	
+	$ip = get_ip();
+	
 	//record the change
-	$db->call('mod_action_insert', array($user_id, "$name lifted ban $ban_id. $disp_reason.", 0, get_ip()));
+	$db->call('mod_action_insert', array($user_id, "$name lifted ban $ban_id from $ip. $disp_reason.", 0, $ip));
 
 
 	//redirect to a page showing the lifted ban
-	header("Location: show_record.php?ban_id=$ban_id") ;
+	header("Location: https://pr2hub.com/bans/show_record.php?ban_id=$ban_id") ;
 }
 
 catch(Exception $e){

--- a/http_server/www/mod/update_guild.php
+++ b/http_server/www/mod/update_guild.php
@@ -73,16 +73,17 @@ function update($db) {
     $guild_name = find('guild_name');
     $note = find('note');
     $owner_id = (int) find('owner_id');
+
+    //grab the guild info
+    $guild = $db->grab_row('guild_select', array($guild_id));
     
-    //check to see if the admin is trying to delete the guild emblem
+    //check to see if the admin is trying to delete the guild emblem, then use gathered info
     if (!empty($_GET['delete_emblem'])) {
 	$emblem = "default-emblem.jpg";
     }
     else {
 	$emblem = $guild->emblem;
     }
-    
-    $guild = $db->grab_row('guild_select', array($guild_id));
 
     $db->call(
 	    'guild_update',


### PR DESCRIPTION
7422130 should make it so editing a guild will preserve the emblem.  The scope of the function got me the first time, then it was not defining a variable earlier in the function but calling it at that time. 
 17th time's the charm, right?

Also in this pull:
 - Hopefully fix ban_edit.php's checkboxes (54d4c71)
 - Fix action logging in ban_edit.php (039d1ec)
 - http->https in ban_edit.php (e065091)
 - Fix broken redirect link in do_lift_ban.php (f96bae8)
 - New language in README.md (9b5a627)