### PR TITLE
Fix folding awards

### DIFF
--- a/http_server/cron/fetch_folding_stats.php
+++ b/http_server/cron/fetch_folding_stats.php
@@ -1,7 +1,5 @@
 <?php
 
-/*
-
 require_once('../fns/all_fns.php');
 
 
@@ -107,7 +105,5 @@ foreach($user_array as $user_str) {
 function output( $str ) {
 	echo( "* $str \n" );
 }
-
-*/
 
 ?>


### PR DESCRIPTION
The server can't award the parts if it doesn't know who got them!

I think this is all that needs to be done in the http_server/cron folder, although there could very well be needed changes in http_server/fns or even still cron.  Please check to make sure everything works.