### PR TITLE
Server crash fixes when using commands in levels, new commands/edits

### DIFF
--- a/multiplayer_server/fns/announce_tournament.php
+++ b/multiplayer_server/fns/announce_tournament.php
@@ -13,4 +13,17 @@ function announce_tournament( $chat ) {
 	}
 }
 
+function tournament_status( $requester ) {
+	if( pr2_server::$tournament ) {
+		$requester->write('systemChat`Tournament mode is on!<br/>'
+			.'Hat: '.Hats::id_to_str(pr2_server::$tournament_hat).'<br/>'
+			.'Speed: '.pr2_server::$tournament_speed.'<br/>'
+			.'Accel: '.pr2_server::$tournament_acceleration.'<br/>'
+			.'Jump: '.pr2_server::$tournament_jumping);
+	}
+	else {
+		$requester->write('systemChat`Tournament mode is off.');
+	}
+}
+
 ?>

--- a/multiplayer_server/rooms/ChatRoom.php
+++ b/multiplayer_server/rooms/ChatRoom.php
@@ -21,7 +21,7 @@ class ChatRoom extends Room {
 
 	public function clear () {
 		for ($i = 0; $i <= $this->keep_count; $i++) {
-			$this->send_chat('systemChat` ', 0);
+			$this->send_chat('systemChat` ');
 		}
 	}
 


### PR DESCRIPTION
 - Fixes server crashes when using /give, /a, /promote, /clear and any chat effects in levels.
 - Doesn't give an error when using functions that a player doesn't have permission to use.
 - Players/server owners can now check tournament status by using /t status, using `tournament_status()` in fns/announce_tournament.php
 - Add emote :shrug:
 - Add /promote for admins (same thing as /give, except the text is "bls1999 has promoted " instead of "bls1999 has given ")
 - Update /help command