### PR TITLE
Fix remember me login

### DIFF
--- a/http_server/fns/data_fns.php
+++ b/http_server/fns/data_fns.php
@@ -86,6 +86,38 @@ function get_ip() {
 }
 
 
+function is_empty($str, $incl_zero=true) {
+	/*
+	$incl_zero: checks if the user wants to include the string "0" in the empty check.
+	If not, empty($str) will make this function return true.
+	*/
+	
+	// if the string length is 0, it's empty
+	if (strlen(trim($str)) === 0) {
+		return true;
+	}
+	// if the string isn't set, it's empty
+	if (!isset($str)) {
+		return true;
+	}
+	// if the string is empty and not 0, it's empty
+	if ($incl_zero) {
+		if (empty($str) && $str != '0') {
+			return true;
+		}
+	}
+	// if the string is empty, it's empty
+	else {
+		if (empty($str)) {
+			return true;
+		}
+	}
+
+	// you're still here? must mean $str isn't empty
+	return false;
+	
+}
+
 
 function poll_servers_strict( $db, $message, $server_ids ) {
 	$servers = poll_servers_2( $db, $message, true, $server_ids );

--- a/http_server/www/login.php
+++ b/http_server/www/login.php
@@ -5,6 +5,7 @@ require_once( '../fns/Encryptor.php' );
 
 $encrypted_login = find( 'i' );
 $version = find( 'version' );
+$in_token = find( 'token' );
 
 $allowed_versions = array('24-dec-2013-v1');
 $guest_login = false;
@@ -19,7 +20,7 @@ $guild_name = '';
 $friends = array();
 $ignored = array();
 
-// ip info and run it through an IP info API (because installing geoip is not worth the hassle)
+// get the user's ip info and run it through an ip info api (because installing geoip is not worth the hassle)
 $ip = get_ip();
 
 try {
@@ -70,7 +71,7 @@ try {
 	if( $origination_domain == 'local' ) {
 		throw new Exception( 'Testing mode has been disabled.' );
 	}
-	if( !isset($user_name) || empty($user_name) || strlen(trim($user_name)) === 0 || strpos($user_name, '`') !== false ) {
+	if( (is_empty($in_token) === true && is_empty($user_name) === true) || strpos($user_name, '`') !== false ) {
 		throw new Exception( 'Invalid user name entered.' );
 	}
 
@@ -101,9 +102,6 @@ try {
 
 		//--- record this attempted log in
 		$db->call( 'login_attempt_insert', array($ip, $login->user_name) );
-
-		//--- check for a token
-		$in_token = find( 'token' );
 
 		//token login
 		if( isset($in_token) && $login->user_name == '' && $login->user_pass == '') {


### PR DESCRIPTION
Remember me is now displaying the error for an invalid username.  This has to do with my check not accounting for token data.  I've added some new checks with the help of a new function (`is_empty()` in `data_fns.php`).