### PR TITLE
Make things easier for admins in message_send.php

### DIFF
--- a/http_server/www/message_send.php
+++ b/http_server/www/message_send.php
@@ -11,7 +11,13 @@ try {
 	$db = new DB();
 	
 	$from_user_id = token_login($db, false);
+	$from_name = id_to_name($from_user_id);
 	$to_user_id = name_to_id($db, $to_name);
+	
+	// let admins use the [url=][/url] tags
+	if($from_name->power >= 3) {
+		$message = preg_replace('/\[url=(.+?)\](.+?)\[\/url\]/', '<a href="\1" target="_blank"><u><font color="#0000FF">\2</font></u></a>', $message);
+	}
 	
 	send_pm( $db, $from_user_id, $to_user_id, $message );
 	


### PR DESCRIPTION
Admins can now use `[url=https://example.com/]My Site![/url]` to link to things instead of needing to type out the long html tags.