### PR TITLE
Fix future possible folding issues in register_user.php

### DIFF
--- a/http_server/www/register_user.php
+++ b/http_server/www/register_user.php
@@ -31,10 +31,10 @@ try{
 	if(is_obsene($name)){
 		throw new Exception('Do try to think of a different name.');
 	}
-	$test_name = preg_replace("/[^a-zA-Z0-9#-.:;=?@~! ]/", "", $name);
+	$test_name = preg_replace("/[^a-zA-Z0-9-.:;=?~! ]/", "", $name);
 	if($test_name != $name){
 		throw new Exception('There is an invalid character in your name. '
-							.'The allowed characters are a-z, 1-9, and !#$%&()*+.:;=?@~.');
+							.'The allowed characters are a-z, 0-9, and !$&()*+.:;=?~.');
 	}
 
 


### PR DESCRIPTION
Users that contain #, %, and @ cannot be folded. I believe it's due to how folding at home stores usernames with those characters and this causes PR2 not to find a match with the usernames to be able to award the tokens and hats. 

Because of this I changed the allowed characters in usernames although % wasn't there so I'm not sure how to make it not allowed. Also 0 is allowed in usernames and technically the invalid character message tells you it is not.