### PR TITLE
Fix update_guild.php after guild transfer merge

### DIFF
--- a/http_server/www/admin/update_guild.php
+++ b/http_server/www/admin/update_guild.php
@@ -84,9 +84,9 @@ function update($db) {
 	
 	if($guild->owner_id !== $owner_id) {
 		$code = 'manual-' . time();
-		$db->call('guild_transfer_insert', array($guild->guild_id, $old_id, $new_id, $code, $ip));
-		$change_id = $db->grab('change_id', 'guild_transfer_select_by_code', array($code));
-		$db->call('guild_transfer_complete', array($change_id, $ip));
+		$db->call('guild_transfer_insert', array($guild->guild_id, $old_id, $new_id, $code, $ip), 'Could not initiate the owner change.');
+		$change_id = $db->grab('change_id', 'guild_transfer_select_by_code', array($code), 'Could not get the owner change ID.');
+		$db->call('guild_transfer_complete', array($change_id, $ip), 'Could not complete the owner change.');
 	}
 	
 	//check to see if the admin is trying to delete the guild emblem
@@ -105,7 +105,7 @@ function update($db) {
 		}
 		
 		// do it
-		$db->call('guild_update', array($guild_id, $guild_name, $emblem, $note, $owner_id));
+		$db->call('guild_update', array($guild_id, $guild_name, $emblem, $note, $owner_id), 'Could not update the guild.');
 	
 		//admin log
 		$admin_name = $admin->name;
@@ -113,7 +113,7 @@ function update($db) {
 		$ip = get_ip();
 		$disp_changes = "Changes: " . $guild_changes;
 		
-		$db->call('admin_action_insert', array($admin_id, "$admin_name updated guild $guild_id from $ip. $disp_changes.", $admin_id, $ip));
+		$db->call('admin_action_insert', array($admin_id, "$admin_name updated guild $guild_id from $ip. $disp_changes.", $admin_id, $ip), 'Could not insert the changes to the admin log.');
 
 	}
 	catch (Exception $e) {
@@ -123,7 +123,7 @@ function update($db) {
 		die();
 	}
 	
-	header("Location: guild_deep_info.php?guild_id=" . urlencode(find('guild_id_submit')));
+	header("Location: guild_deep_info.php?guild_id=" . urlencode($guild->guild_id));
 	die();
 
 }

--- a/http_server/www/guild_transfer.php
+++ b/http_server/www/guild_transfer.php
@@ -118,7 +118,7 @@ function start_transfer($db, $old_name, $guild) {
 	}
 	
 	// check if the emails match
-	if ($email != $old_email) {
+	if (strtolower($email) != strtolower($old_email)) {
 		throw new Exception("The email address you entered is incorrect.");
 	}
 	

--- a/http_server/www/guild_transfer.php
+++ b/http_server/www/guild_transfer.php
@@ -84,10 +84,11 @@ function output_form($user, $guild) {
 	
 	echo 'Your Email Address: <input type="text" name="email"><br>';
 	echo 'Your Password: <input type="password" name="pass"><br>';
-	echo 'New Guild Owner\'s Username: <input type="text" name="new_owner"><br>';
+	echo 'New Guild Owner\'s Username: <input type="text" name="new_owner"><br><br>';
 	echo '<input type="hidden" name="action" value="submit">';
 	
-	echo '<br/>';
+	echo 'NOTE: You may only transfer guild ownership once per week. If you still want to proceed, click submit below.<br><br>';
+
 	echo '<input type="submit" value="Submit">&nbsp;(no confirmation!)';
 	echo '</form>';
 	

--- a/http_server/www/guild_transfer.php
+++ b/http_server/www/guild_transfer.php
@@ -63,7 +63,7 @@ try {
 
 catch (Exception $e) {
 	$message = $e->getMessage();
-	echo "Error: $message.";
+	echo "Error: $message";
 	output_footer();
 	die();
 }
@@ -159,7 +159,7 @@ function start_transfer($db, $old_name, $guild) {
 	$from = 'Fred the Giant Cactus <contact@jiggmin.com>';
 	$to = $old_user->email;
 	$subject = 'PR2 Guild Transfer Confirmation';
-	$body = "Howdy $safe_old_name,\n\nWe received a request to change the owner of your guild <b>$safe_guild_name</b> to <b>$safe_new_name</b>. If you requested this change, please click the link below to complete the guild ownership transfer.\n\nhttps://pr2hub.com/confirm_guild_transfer.php?code=$code\n\nIf you didn't request this change, you may need to change your password.\n\nAll the best,\nFred";
+	$body = "Howdy $safe_old_name,\n\nWe received a request to change the owner of your guild $safe_guild_name to $safe_new_name. If you requested this change, please click the link below to complete the guild ownership transfer.\n\nhttps://pr2hub.com/confirm_guild_transfer.php?code=$code\n\nIf you didn't request this change, you may need to change your password.\n\nAll the best,\nFred";
 	send_email($from, $to, $subject, $body);
 	
 	// tell the world

--- a/http_server/www/remove_level.php
+++ b/http_server/www/remove_level.php
@@ -23,10 +23,10 @@ try{
 	}
 	
 	// check for the level's information
-	$level = $db->grab_row( 'level_select', array($level_id) );
+	$level = $db->grab_row('level_select', array($level_id));
 	$l_title = $level->title;
 	$l_creator_id = (int) $level->user_id;
-	$l_creator = id_to_name($l_creator_id);
+	$l_creator = id_to_name($db, $level->user_id);
 	$l_note = $level->note;
 	
 	// unpublish the level

--- a/http_server/www/remove_level.php
+++ b/http_server/www/remove_level.php
@@ -25,7 +25,6 @@ try{
 	// check for the level's information
 	$level = $db->grab_row('level_select', array($level_id));
 	$l_title = $level->title;
-	$l_creator_id = (int) $level->user_id;
 	$l_creator = id_to_name($db, $level->user_id);
 	$l_note = $level->note;
 	


### PR DESCRIPTION
change `guild_transfer_select` to `guild_transfer_select_by_code`.

Also, it looks like I've already added the code for requester IP and confirmer IP to guild_transfer.php and confirm_guild_transfer.php.  Can you make this information available to admins by calling `guild_transfers_select_by_guild` in guild_deep_info.php?  This would make the information we see pretty much identical to the email change information.