### PR TITLE
Update delete_old_accounts.php

### DIFF
--- a/http_server/cron/delete_old_accounts.php
+++ b/http_server/cron/delete_old_accounts.php
@@ -26,7 +26,7 @@ while($row = $result->fetch_object()) {
 	}
 
 	$str = "$i $user_id plays: $play_count rank: $rank.";
-	if($play_count > 50 || $rank > 10) {
+	if($play_count > 1000 || $rank > 20) {
 		output("$str SPARE");
 	}
 	else {


### PR DESCRIPTION
I thoroughly agree with the idea of a "script" which cleans out inactive/unused accounts however I'd like to suggest some small changes to the algorithm which is used to determine whether an account is unused. As of right now when executed the script collects a list of users from the database which have been inactive for a time length greater than three years, an account is then deleted if it meets the following requirements; has not yet reached rank ten and a total level play count which has not reached fifty. Personally I feel these values could be increased and still reflect the definition of an unused/inactive account, therefore my suggestion is to increase the level required to twenty as this would also coincide with the rank required to create a guild and I also feel inclined to suggest an increase of the minimum play count to five hundred or a thousand as fifty is a very measly amount and was more often than not easily achieved just by uploading a single level once. These changes aren't exactly a priority nor a necessity however I feel like myself and several if not many other community members would like to see this change as it would result in the release of more usernames which had been taken in the past and rarely used.