### PR TITLE
Fix message reporting again

### DIFF
--- a/http_server/www/message_report.php
+++ b/http_server/www/message_report.php
@@ -4,11 +4,8 @@ header("Content-type: text/plain");
 
 require_once('../fns/all_fns.php');
 
-$message_id = $_POST['message_id'];
-$safe_message_id = mysqli_real_escape_string($message_id);
-$safe_reporter_ip = mysqli_real_escape_string($ip);
-$safe_time = mysqli_real_escape_string($time);
-$time = time();
+$message_id = (int) $_POST['message_id'];
+$time = (int) time();
 $ip = get_ip();
 
 try {
@@ -35,7 +32,7 @@ try {
 	$result = $db->query("SELECT COUNT(*)
 								AS count
 								FROM messages_reported
-							 	WHERE message_id = '$safe_message_id'
+							 	WHERE message_id = '$message_id'
 								");
 	if(!$result) {
 		throw new Exception('Could not check if the message was already reported.');
@@ -49,14 +46,13 @@ try {
 	// pull the selected message from the db
 	$result = $db->query("SELECT *
 								FROM messages
-								WHERE message_id = '$safe_message_id'
+								WHERE message_id = '$message_id'
 								LIMIT 0, 1");
 	if(!$result){
 		throw new Exception('Could not retrieve message.');
 	}
 	if($result->num_rows <= 0) {
-		$safe_message_id = htmlspecialchars($message_id);
-		throw new Exception("The message you tried to report ($safe_message_id) doesn't exist.");
+		throw new Exception("The message you tried to report ($message_id) doesn't exist.");
 	}
 	
 	
@@ -68,20 +64,21 @@ try {
 	
 	
 	// insert the message into the reported messages table
-	$safe_to_user_id = mysqli_real_escape_string($row->to_user_id);
-	$safe_from_user_id = mysqli_real_escape_string($row->from_user_id);
+	$to_user_id = (int) $row->to_user_id;
+	$from_user_id = (int) $row->from_user_id;
+	$sent_time = (int) $row->time;
 	$safe_message = mysqli_real_escape_string($row->message);
-	$safe_sent_time = mysqli_real_escape_string($row->time);
 	$safe_from_ip = mysqli_real_escape_string($row->ip);
+	$safe_reporter_ip = mysqli_real_escape_string($ip);
 	
 	$result = $db->query("INSERT INTO messages_reported
-								 	SET to_user_id = '$safe_to_user_id',
-										from_user_id = '$safe_from_user_id',
+								 	SET to_user_id = '$to_user_id',
+										from_user_id = '$from_user_id',
 										reporter_ip = '$safe_reporter_ip',
 										from_ip = '$safe_from_ip',
-										sent_time = '$safe_sent_time',
-										reported_time = '$safe_time',
-										message_id = '$safe_message_id',
+										sent_time = '$sent_time',
+										reported_time = '$time',
+										message_id = '$message_id',
 										message = '$safe_message'");
 	
 	if(!$result){


### PR DESCRIPTION
This is a ballsy move I'm making here, so bear with me.

Instead of using `mysqli_real_escape_string` (which seems to have broken something in checking if the message exists) for the problematic variables, it makes more sense to just convert the strings that should contain numbers (like the user ids, time, etc) to integers.

Theoretically, that should fix it; However, I've been saying that for the past 2 weeks I've been trying to fix this god-awful script.