### PR TITLE
Fixes to rate limiting, bugs in certain files

### DIFF
--- a/http_server/www/account_change_email.php
+++ b/http_server/www/account_change_email.php
@@ -24,8 +24,7 @@ try {
 	}
 	
 	// rate limiting
-	rate_limit('change-email-attempt-'.$ip, 30, 1, 'Please wait at least 30 seconds before attempting to change the email address on your account again.');
-	rate_limit('change-email-attempt-'.$ip, 300, 5, 'You may only send a maximum of 5 email change requests every 5 minutes. Try again later.');
+	rate_limit('change-email-attempt-'.$ip, 5, 1);
 
 	//--- sanity check
 	if( !isset($encrypted_data) ) {
@@ -45,6 +44,11 @@ try {
 
 	// check their login
 	$user_id = token_login($db, false);
+	
+	// more rate limiting
+	rate_limit('change-email-attempt-'.$user_id, 5, 1);
+	
+	// get user info
 	$user = $db->grab_row('user_select', array($user_id));
 	$user_name = $user->name;
 	$old_email = $user->email;
@@ -64,7 +68,7 @@ try {
 	
 	// sanity check: check for invalid email
 	if (!valid_email($new_email)) {
-		throw new Exception("'$safe_new_email' is not a valid email address.");
+		throw new Exception("\"$safe_new_email\" is not a valid email address.");
 	}
 	
 	// rate limiting

--- a/http_server/www/account_confirm_email_change.php
+++ b/http_server/www/account_confirm_email_change.php
@@ -3,16 +3,18 @@
 require_once( '../fns/all_fns.php' );
 require_once( '../fns/output_fns.php' );
 
+$code = $_GET['code'];
+$ip = get_ip();
+
 try {
-	
-	// get info
-	$code = $_GET['code'];
-	$ip = get_ip();
 	
 	// sanity check: check for the code
 	if (is_empty($code)) {
 		throw new Exception('No code found.');
 	}
+	
+	// rate limiting
+	rate_limit('account-confirm-email-change-'.$ip, 5, 1);
 	
 	// connect
 	$db = new DB();

--- a/http_server/www/account_confirm_email_change.php
+++ b/http_server/www/account_confirm_email_change.php
@@ -38,7 +38,7 @@ try {
 	
 	// tell it to the world
 	output_header('Confirm Email Change');
-	echo "Great success! Your email address has been changed from '$safe_old_email' to '$safe_new_email'.";
+	echo "Great success! Your email address has been changed from \"$safe_old_email\" to \"$safe_new_email\".";
 	output_footer();
 }
 

--- a/http_server/www/add_friend.php
+++ b/http_server/www/add_friend.php
@@ -16,8 +16,7 @@ try {
 	}
 	
 	// rate limiting
-	rate_limit('friends-list-'.$ip, 3, 1);
-	rate_limit('friends-list-'.$ip, 30, 5);
+	rate_limit('friends-list-'.$ip, 3, 2);
 	
 	// connect
 	$db = new DB();
@@ -26,8 +25,7 @@ try {
 	$user_id = token_login($db, false);
 	
 	// more rate limiting
-	rate_limit('friends-list-'.$user_id, 3, 1);
-	rate_limit('friends-list-'.$user_id, 30, 5);
+	rate_limit('friends-list-'.$user_id, 3, 2);
 	
 	// get the new friend's id
 	$friend_id = name_to_id($db, $friend_name);

--- a/http_server/www/admin/search_by_email.php
+++ b/http_server/www/admin/search_by_email.php
@@ -48,7 +48,7 @@ try {
 	}
 	
 	// protect the db
-	$safe_email = mysqli_real_escape_string($email);
+	$safe_email = addslashes($email);
 
 	// if there's an email set, let's get data from the db
 	$result = $db->query("SELECT power, name, active_date
@@ -62,10 +62,10 @@ try {
 	}
 	
 	// protect the user
-	$safe_email = htmlspecialchars($email);
+	$disp_email = htmlspecialchars($email);
   
 	// show the search form
-	output_search($safe_email);
+	output_search($disp_email);
 	
 	// only gonna get here if there were results
 	while ($row = $result->fetch_object()) {

--- a/http_server/www/backups/backups.php
+++ b/http_server/www/backups/backups.php
@@ -5,12 +5,13 @@ require_once('../../fns/output_fns.php');
 require_once('../../fns/classes/S3.php');
 
 $ip = get_ip();
+$desc = "<p><center>Welcome to PR2's level restore system!<br>You can use this tool to restore any level that was modified or deleted in the past month.</center></p>";
 
 try {
 	
 	// rate limiting
-	rate_limit('level-backups-'.$ip, 5, 1);
-	rate_limit('level-backups-'.$ip, 30, 5);
+	rate_limit('level-backups-'.$ip, 5, 2);
+	rate_limit('level-backups-'.$ip, 30, 10);
 	
 	// connect
 	$db = new DB();
@@ -85,11 +86,13 @@ try {
 		}
 		
 		//success
+		echo $desc;
+		echo '<p>---</p>';
 		echo "<p><b>".htmlspecialchars($title)." v$version</b> restored successfully!</p>";
 	}
 	
 	else {
-		echo "<p>Welcome to PR2's level restore system. You can use this tool to restore any level that was modified or deleted in the past month.</p>";
+		echo $desc;
 	}
 	
 	

--- a/http_server/www/ban_user.php
+++ b/http_server/www/ban_user.php
@@ -51,10 +51,6 @@ try {
 	$mod_user_name = $mod->name;
 	$mod_power = 2;
 	
-	// more rate limiting
-	rate_limit('ban-'.$mod_user_id, 5, 1);
-	
-	
 	// limit ban length
 	if($duration > $mod->max_ban) {
 		$duration = $mod->max_ban;

--- a/http_server/www/change_password.php
+++ b/http_server/www/change_password.php
@@ -33,7 +33,7 @@ try {
 	}
 	
 	// rate limiting
-	rate_limit('password-change-attempt-'.$ip, 30, 1, 'Please wait at least 30 seconds before trying to change your password again.');
+	rate_limit('password-change-attempt-'.$ip, 5, 1, 'Please wait at least 5 seconds before trying to change your password again.');
 
 	// connect
 	$db = new DB();

--- a/http_server/www/check_login.php
+++ b/http_server/www/check_login.php
@@ -8,7 +8,7 @@ $ip = get_ip();
 try {
 	
 	// rate limiting
-	rate_limit('check-login-'.$ip, 15, 1);
+	rate_limit('check-login-'.$ip, 10, 1);
 	
 	// connect to the db
 	$db = new DB();

--- a/http_server/www/confirm_guild_transfer.php
+++ b/http_server/www/confirm_guild_transfer.php
@@ -16,7 +16,7 @@ try {
 	}
 	
 	// rate limiting
-	rate_limit('confirm-guild-transfer-'.$ip, 30, 1, "Please wait at least 30 seconds before attempting to confirm another guild transfer.");
+	rate_limit('confirm-guild-transfer-'.$ip, 5, 1);
 	
 	// connect
 	$db = new DB();

--- a/http_server/www/delete_level.php
+++ b/http_server/www/delete_level.php
@@ -38,7 +38,7 @@ try {
 	$user_id = token_login($db, false);
 	
 	// more rate limiting
-	rate_limit('delete-level-attempt-'.$ip, 10, 1, 'Please wait at least 10 seconds before trying to delete another level.');
+	rate_limit('delete-level-attempt-'.$user_id, 10, 1, 'Please wait at least 10 seconds before trying to delete another level.');
 	rate_limit('delete-level-'.$ip, 3600, 5, 'You may only delete 5 levels per hour. Try again later.');
 	rate_limit('delete-level-'.$user_id, 3600, 5, 'You may only delete 5 levels per hour. Try again later.');
 	

--- a/http_server/www/emblem_upload.php
+++ b/http_server/www/emblem_upload.php
@@ -21,8 +21,8 @@ try {
 	}
 	
 	// rate limiting
-	rate_limit('emblem-upload-attempt-'.$ip, 60, 1, "Please wait at least one minute before trying to upload a guild emblem again.");
-	rate_limit('emblem-upload-attempt-'.$ip, 3600, 10, "You can attempt a maximum of 10 guild emblem uploads per hour. Try again later.");
+	rate_limit('emblem-upload-attempt-'.$ip, 15, 1, "Please wait at least 15 seconds before trying to upload a guild emblem again.");
+	rate_limit('emblem-upload-attempt-'.$ip, 900, 10, "Please wait at least 15 minutes before trying to upload a guild emblem again.");
 	
 	$image = file_get_contents("php://input");
 	$image_rendered = imagecreatefromstring($image);
@@ -35,6 +35,12 @@ try {
 	
 	// check their login
 	$user_id = token_login($db, false);
+	
+	// more rate limiting
+	rate_limit('emblem-upload-attempt-'.$user_id, 15, 1, "Please wait at least 15 seconds before trying to upload a guild emblem again.");
+	rate_limit('emblem-upload-attempt-'.$user_id, 900, 10, "Please wait at least 15 minutes before trying to upload a guild emblem again.");
+	
+	// get user info
 	$account = $db->grab_row( 'user_select_expanded', array($user_id) );
 	
 	// sanity checks

--- a/http_server/www/forgot_password.php
+++ b/http_server/www/forgot_password.php
@@ -25,7 +25,7 @@ try {
 	}
 	
 	// rate limiting
-	rate_limit('forgot-password-attempt-'.$ip, 60, 1, 'Please wait at least one minute before submitting another request to recover your account.');
+	rate_limit('forgot-password-attempt-'.$ip, 5, 1);
 
 	// sanity check: is it a valid email address?
 	if(!valid_email($email)){

--- a/http_server/www/get_levels.php
+++ b/http_server/www/get_levels.php
@@ -10,7 +10,7 @@ $ip = get_ip();
 try {
 	
 	// rate limiting
-	rate_limit('get-levels-'.$ip, 15, 1, "Please wait at least 15 seconds before loading your levels again.");
+	rate_limit('get-levels-'.$ip, 3, 2);
 	
 	// connect
 	$db = new DB();
@@ -19,7 +19,7 @@ try {
 	$user_id = token_login($db);
 	
 	// more rate limiting
-	rate_limit('get-levels-'.$user_id, 15, 1, "Please wait at least 15 seconds before loading your levels again.");
+	rate_limit('get-levels-'.$user_id, 3, 2);
 	
 	// get levels
 	$result = $db->call('levels_select_by_owner', array($user_id));

--- a/http_server/www/get_player_info_2.php
+++ b/http_server/www/get_player_info_2.php
@@ -12,8 +12,7 @@ $ip = get_ip();
 try {
 	
 	// rate limit
-	rate_limit('get-player-info-2-'.$ip, 3, 1);
-	rate_limit('get-player-info-2-'.$ip, 60, 10);
+	rate_limit('get-player-info-2-'.$ip, 3, 2);
 
 	// connect
 	$db = new DB();
@@ -21,8 +20,7 @@ try {
 	// check their login
 	try {
 		$user_id = token_login($db);
-		rate_limit('get-player-info-2-'.$user_id, 3, 1);
-		rate_limit('get-player-info-2-'.$user_id, 60, 10);
+		rate_limit('get-player-info-2-'.$user_id, 3, 2);
 	}
 	catch(Exception $e) {
 		$friend = 0;

--- a/http_server/www/get_user_list.php
+++ b/http_server/www/get_user_list.php
@@ -22,8 +22,7 @@ try {
 	}
 	
 	// rate limiting
-	rate_limit("user-list-$table-$ip", 5, 1);
-	rate_limit("user-list-$table-$ip", 30, 5);
+	rate_limit("user-list-$table-$ip", 5, 2);
 	
 	// connect
 	$db = new DB();
@@ -31,8 +30,8 @@ try {
 	// check their login
 	$user_id = token_login($db);
 	
-	// rate limiting
-	rate_limit("user-list-$table-$user_id", 30, 5);
+	// more rate limiting
+	rate_limit("user-list-$table-$user_id", 5, 2);
 	
 	// get the information from the database
 	$result = $db->query("SELECT users.name, users.power, users.status, pr2.rank, pr2.hat_array, rank_tokens.used_tokens

--- a/http_server/www/guild_create.php
+++ b/http_server/www/guild_create.php
@@ -17,13 +17,18 @@ try {
 	}
 	
 	// rate limiting
-	rate_limit('guild-create-attempt-'.$ip, 30, 1, "Please wait at least 30 seconds before attempting to create a guild again.");
+	rate_limit('guild-create-attempt-'.$ip, 10, 3, "Please wait at least 10 seconds before attempting to create a guild again.");
 	
 	// connect
 	$db = new DB();
 	
 	// check their login
 	$user_id = token_login($db, false);
+	
+	// more rate limiting
+	rate_limit('guild-create-attempt-'.$user_id, 10, 3, "Please wait at least 10 seconds before attempting to create a guild again.");
+	
+	// get user info
 	$account = $db->grab_row( 'user_select_expanded', array($user_id) );
 	
 	// sanity checks

--- a/http_server/www/guild_delete.php
+++ b/http_server/www/guild_delete.php
@@ -9,7 +9,7 @@ $ip = get_ip();
 try {
 	
 	// rate limiting
-	rate_limit('guild-delete-'.$ip, 5, 1);
+	rate_limit('guild-delete-'.$ip, 5, 2);
 	
 	// connect to the db
 	$db = new DB();
@@ -21,7 +21,7 @@ try {
 	$ip = $mod->ip;
 	
 	// more rate limiting
-	rate_limit('guild-delete-'.$mod_id, 5, 1);
+	rate_limit('guild-delete-'.$mod_id, 5, 2);
 	
 	// check if the guild exists and make some rad variables
 	$guild = $db->grab_row('guild_select', array($guild_id), 'Could not find a guild with that id.');

--- a/http_server/www/guild_edit.php
+++ b/http_server/www/guild_edit.php
@@ -17,17 +17,22 @@ try {
 	}
 	
 	// rate limiting
-	rate_limit('guild-edit-attempt-'.$ip, 15, 1, "Please wait at least 15 seconds before editing your guild again.");
+	rate_limit('guild-edit-attempt-'.$ip, 10, 3, "Please wait at least 10 seconds before editing your guild again.");
 	
-	//--- connect to the db
+	// connect to the db
 	$db = new DB();
 	
-	//--- check their login
+	// check their login
 	$user_id = token_login($db, false);
+	
+	// more rate limiting
+	rate_limit('guild-edit-attempt-'.$user_id, 10, 3, "Please wait at least 10 seconds before editing your guild again.");
+	
+	// get account and guild info
 	$account = $db->grab_row( 'user_select_expanded', array( $user_id ) );
 	$guild = $db->grab_row( 'guild_select', array( $account->guild ) );
 	
-	//--- sanity check
+	// sanity checks
 	if( $account->power <= 0 ) {
 		throw new Exception( 'Guests cannot edit guilds.' );
 	}
@@ -56,11 +61,11 @@ try {
 		throw new Exception('I\'m not sure what would happen if you didn\'t enter a guild name, but it would probably destroy the world.');
 	}
 	
-	//--- edit guild in db
+	// edit guild in db
 	$db->call( 'guild_update', array( $guild->guild_id, $guild_name, $emblem, $note, $guild->owner_id ), 'A guild already exists with that name.' );
 	
 	
-	//--- tell it to the world
+	// tell it to the world
 	$reply = new stdClass();
 	$reply->success = true;
 	$reply->message = 'Guild edited successfully!';

--- a/http_server/www/guild_info.php
+++ b/http_server/www/guild_info.php
@@ -13,8 +13,7 @@ $ip = get_ip();
 try {
 	
 	// rate limiting
-	rate_limit('guild-info-'.$ip, 5, 1);
-	rate_limit('guild-info'.$ip, 60, 10);
+	rate_limit('guild-info-'.$ip, 3, 2);
 	
 	
 	// connect

--- a/http_server/www/guild_invite.php
+++ b/http_server/www/guild_invite.php
@@ -11,7 +11,7 @@ $ip = get_ip();
 try {
 	
 	// rate limiting
-	rate_limit('guild-invite-attempt-'.$ip, 30, 1, "Please wait 30 seconds before attempting to invite another player to your guild.");
+	rate_limit('guild-invite-attempt-'.$ip, 5, 2, "Please wait at least 5 seconds before attempting to invite another player to your guild.");
 	
 	// connect
 	$db = new DB();

--- a/http_server/www/guild_leave.php
+++ b/http_server/www/guild_leave.php
@@ -14,29 +14,29 @@ try {
 	}
 	
 	// rate limiting
-	rate_limit('guild-leave-attempt-'.$ip, 30, 1, "Please wait at least 30 seconds before attempting to leave your guild again.");
+	rate_limit('guild-leave-attempt-'.$ip, 5, 1);
 	
-	//--- connect to the db
+	// connect to the db
 	$db = new DB();
 	
 	
-	//--- get thier login
+	// get their login
 	$user_id = token_login($db, false);
 	$account = $db->grab_row( 'user_select_expanded', array($user_id) );
 	
 	
-	//--- sanity check
+	// sanity check
 	if( $account->guild == 0 ) {
 		throw new Exception( 'You are not a member of a guild.' );
 	}
 	
 	
-	//--- leave the guild
+	// leave the guild
 	$db->call( 'guild_increment_member', array( $account->guild, -1 ) );
 	$db->call( 'user_update_guild', array( $user_id, 0 ) );
 	
 	
-	//--- tell it to the world
+	// tell it to the world
 	$reply = new stdClass();
 	$reply->success = true;
 	$reply->message = 'You have left the guild.';

--- a/http_server/www/guild_message.php
+++ b/http_server/www/guild_message.php
@@ -22,7 +22,7 @@ try {
 	}
 	
 	// rate limit
-	rate_limit('guildMessage-attempt-'.$ip, 60, 1, "Please wait at least one minute before trying to message your guild again.");
+	rate_limit('guildMessage-attempt-'.$ip, 15, 1, "Please wait at least 15 seconds before trying to message your guild again.");
 	
 	// connect
 	$db = new DB();
@@ -37,7 +37,7 @@ try {
 	}
 	
 	// confirm that there's a message
-	if($message === NULL) {
+	if(is_empty($message)) {
 		throw new Exception('You must enter a valid message.');
 	}
 	

--- a/http_server/www/guild_transfer.php
+++ b/http_server/www/guild_transfer.php
@@ -9,7 +9,7 @@ $ip = get_ip();
 try {
 
 	// rate limit
-	rate_limit('gui-guild-transfer-connect-'.$ip, 5, 1, 'Please wait at least 5 seconds before trying to reload this page.');
+	rate_limit('gui-guild-transfer-connect-'.$ip, 5, 2, 'Please wait at least 5 seconds before trying to reload this page.');
 	
 	// what is the user trying to do
 	if (is_empty($_POST['action'])) {
@@ -107,7 +107,7 @@ function start_transfer($db, $old_name, $guild) {
 	$ip = get_ip();
 	
 	// rate limiting
-	rate_limit('gui-guild-transfer-'.$ip, 60, 1, 'Please wait at least one minute before attempting to transfer your guild again.');
+	rate_limit('gui-guild-transfer-'.$ip, 10, 1, 'Please wait at least 10 seconds before attempting to transfer your guild again.');
 	
 	// receive variables from post
 	$email = $_POST['email'];

--- a/http_server/www/guilds_top.php
+++ b/http_server/www/guilds_top.php
@@ -11,8 +11,7 @@ $ip = get_ip();
 try {
 	
 	// rate limiting
-	rate_limit('guilds-top-'.$ip, 5, 1);
-	rate_limit('guilds-top-'.$ip, 60, 10);
+	rate_limit('guilds-top-'.$ip, 5, 3);
 	
 	//--- connect to the db
 	$db = new DB();

--- a/http_server/www/ignore_user.php
+++ b/http_server/www/ignore_user.php
@@ -15,8 +15,7 @@ try {
 	}
 	
 	// rate limiting
-	rate_limit('ignored-list-'.$ip, 3, 1);
-	rate_limit('ignored-list-'.$ip, 30, 5);
+	rate_limit('ignored-list-'.$ip, 3, 2);
 	
 	// connect
 	$db = new DB();
@@ -25,8 +24,7 @@ try {
 	$user_id = token_login($db, false);
 	
 	// more rate limiting
-	rate_limit('ignored-list-'.$user_id, 3, 1);
-	rate_limit('ignored-list-'.$user_id, 30, 5);
+	rate_limit('ignored-list-'.$user_id, 3, 2);
 	
 	// get the ignored user's id
 	$ignored_id = name_to_id($db, $ignored_name);

--- a/http_server/www/level_pass_check.php
+++ b/http_server/www/level_pass_check.php
@@ -5,17 +5,16 @@ header("Content-type: text/plain");
 require_once('../fns/all_fns.php');
 require_once('../fns/Encryptor.php');
 
-$level_id = find_no_cookie('courseID', '');
+$level_id = (int) default_val($_GET['courseID'], 0);
 $hash = find_no_cookie('hash', '');
 
 try {
 	
 	// rate limiting
-	rate_limit('level-pass-'.$ip, 3, 1);
-	rate_limit('level-pass-'.$ip, 60, 10);
+	rate_limit('level-pass-'.$ip, 3, 2);
 
 	// sanity
-	if(is_empty($level_id) || is_empty($hash)) {
+	if(is_empty($level_id, false) || is_empty($hash)) {
 		throw new Exception('Invalid input. ' . join(', ', $_GET));
 	}
 
@@ -26,8 +25,7 @@ try {
 	$user_id = token_login($db, false);
 	
 	// more rate limiting
-	rate_limit('level-pass-'.$user_id, 3, 1);
-	rate_limit('level-pass-'.$user_id, 60, 10);
+	rate_limit('level-pass-'.$user_id, 3, 2);
 
 	// check the pass
 	$hash2 = sha1($hash . $LEVEL_PASS_SALT);

--- a/http_server/www/login.php
+++ b/http_server/www/login.php
@@ -1,11 +1,13 @@
 <?php
 
+header("Content-type: text/plain");
+
 require_once( '../fns/all_fns.php' );
 require_once( '../fns/Encryptor.php' );
 
 $encrypted_login = $_POST['i'];
 $version = $_POST['version'];
-$in_token = $_POST['token'];
+$in_token = find('token');
 
 $allowed_versions = array('24-dec-2013-v1');
 $guest_login = false;
@@ -46,8 +48,8 @@ try {
 
 
 	// rate limiting
-	rate_limit('login-'.$ip, 10, 2, 'Please wait at least 10 seconds before trying to log in again.');
-	rate_limit('login-'.$ip, 60, 5, 'Only 5 logins per minute per IP are accepted.');
+	rate_limit('login-'.$ip, 5, 2, 'Please wait at least 5 seconds before trying to log in again.');
+	rate_limit('login-'.$ip, 60, 10, 'Only 10 logins per minute per IP are accepted.');
 
 
 	//--- decrypt login data
@@ -360,10 +362,10 @@ Thanks for playing, I hope you enjoy.
 	$reply->emblem = $emblem;
 	$reply->userId = $user_id;
 	
-	// debugging
-	if ($user_name == 'bls') {
-		$reply->domain = $origination_domain;
-		$reply->message = "This is a test message! If you can see this, what you're trying to accomplish might just be possible. Hooray!";
+	// allowed domain check
+	$ref = check_ref();
+	if ($ref !== true) {
+		$reply->message = "It looks like you're using PR2 from a third-party website. For security reasons, some game features may be disabled. To access a version of the game with all features available to you, play from an approved site such as pr2hub.com.";
 	}
 	
 	echo json_encode( $reply );

--- a/http_server/www/logout.php
+++ b/http_server/www/logout.php
@@ -8,7 +8,7 @@ $ip = get_ip();
 try {
 	
 	// rate limiting
-	rate_limit('logout-'.$ip, 10, 2, 'Please wait at least 10 seconds before attempting to log out again.');
+	rate_limit('logout-'.$ip, 5, 2, 'Please wait at least 5 seconds before attempting to log out again.');
 	rate_limit('logout-'.$ip, 60, 10, 'Only 10 logout requests per minute per IP are accepted.');
 	
 	if(isset($_COOKIE['token'])) {

--- a/http_server/www/message_delete.php
+++ b/http_server/www/message_delete.php
@@ -14,14 +14,16 @@ try {
 	}
 	
 	// rate limiting
-	rate_limit('message-delete'.$ip, 5, 1, "Please wait at least 5 seconds before trying to delete another PM.");
-	rate_limit('message-delete-'.$ip, 120, 20);
+	rate_limit('message-delete'.$ip, 5, 2, "Please wait at least 5 seconds before trying to delete another PM.");
 	
 	// connect
 	$db = new DB();
 	
 	// check their login
 	$user_id = token_login($db);
+	
+	// more rate limiting
+	rate_limit('message-delete'.$user_id, 5, 2, "Please wait at least 5 seconds before trying to delete another PM.");
 	
 	// delete the message from the database
 	$db->call('message_delete', array($user_id, $message_id));

--- a/http_server/www/message_report.php
+++ b/http_server/www/message_report.php
@@ -17,7 +17,7 @@ try {
 	}
 	
 	// rate limiting
-	rate_limit('message-report-'.$ip, 5, 1, "Please wait at least 5 seconds before trying to report another PM.");
+	rate_limit('message-report-'.$ip, 5, 2, "Please wait at least 5 seconds before trying to report another PM.");
 	rate_limit('message-report-'.$ip, 60, 5);
 	
 	// connect
@@ -27,6 +27,7 @@ try {
 	$user_id = token_login($db, false);
 	
 	// more rate limiting
+	rate_limit('message-report-'.$user_id, 5, 2, "Please wait at least 5 seconds before trying to report another PM.");
 	rate_limit('message-report-'.$user_id, 60, 5);
 	
 	// make sure the message isn't already reported

--- a/http_server/www/messages_get.php
+++ b/http_server/www/messages_get.php
@@ -13,7 +13,7 @@ $ip = get_ip();
 try {
 	
 	// rate limiting
-	rate_limit( 'get-messages-'.$ip, 5, 1 );
+	rate_limit( 'get-messages-'.$ip, 3, 2 );
 	rate_limit( 'get-messages-'.$ip, 60, 10 );
 	
 	// connect
@@ -23,7 +23,7 @@ try {
 	$user_id = token_login($db);
 	
 	// more rate limiting
-	rate_limit( 'get-messages-'.$user_id, 5, 1 );
+	rate_limit( 'get-messages-'.$user_id, 3, 2 );
 	rate_limit( 'get-messages-'.$user_id, 60, 10 );
 	
 	$safe_user_id = $db->escape( $user_id );

--- a/http_server/www/mod/archive_message.php
+++ b/http_server/www/mod/archive_message.php
@@ -9,8 +9,7 @@ $ip = get_ip();
 try {
 
 	// rate limiting
-	rate_limit('mod-archive-message-'.$ip, 3, 1);
-	rate_limit('mod-archive-message-'.$ip, 15, 3);
+	rate_limit('mod-archive-message-'.$ip, 3, 2);
 
 	// connect
 	$db = new DB();
@@ -28,11 +27,6 @@ catch(Exception $e) {
 }
 
 try {
-	
-	// more rate limiting
-	$mod_id = $mod->user_id;
-	rate_limit('mod-archive-message-'.$mod_id, 3, 1);
-	rate_limit('mod-archive-message-'.$mod_id, 15, 3);
 	
 	// archive the message
 	$result = $db->query("UPDATE messages_reported

--- a/http_server/www/mod/ban.php
+++ b/http_server/www/mod/ban.php
@@ -16,8 +16,7 @@ try {
 	}
 	
 	// rate limiting
-	rate_limit('mod-ban-'.$ip, 5, 1);
-	rate_limit('mod-ban-'.$ip, 30, 5);
+	rate_limit('mod-ban-'.$ip, 2, 1);
 	
 	// connect
 	$db = new DB();
@@ -38,11 +37,6 @@ try {
 	
 	// output header w/ mod nav
 	output_header('Ban User', true);
-	
-	// rate limiting
-	$mod_id = $mod->user_id;
-	rate_limit('mod-ban-'.$mod_id, 5, 1);
-	rate_limit('mod-ban-'.$mod_id, 30, 5);
 
 	// get the user's name
 	$row = $db->grab_row('user_select', array($user_id));

--- a/http_server/www/mod/ban.php
+++ b/http_server/www/mod/ban.php
@@ -16,7 +16,7 @@ try {
 	}
 	
 	// rate limiting
-	rate_limit('mod-ban-'.$ip, 2, 1);
+	rate_limit('mod-ban-'.$ip, 3, 2);
 	
 	// connect
 	$db = new DB();

--- a/http_server/www/mod/ban_edit.php
+++ b/http_server/www/mod/ban_edit.php
@@ -15,8 +15,7 @@ try {
 	}
 	
 	// rate limiting
-	rate_limit('mod-ban-edit-'.$ip, 5, 1);
-	rate_limit('mod-ban-edit-'.$ip, 30, 5);
+	rate_limit('mod-ban-edit-'.$ip, 2, 1);
 
 	//connect
 	$db = new DB();

--- a/http_server/www/mod/do_lift_ban.php
+++ b/http_server/www/mod/do_lift_ban.php
@@ -15,14 +15,8 @@ try {
 		throw new Exception("Invalid request method.");
 	}
 
-	// sanity check: are any values blank?
-	if(is_empty($ban_id, false) || is_empty($reason)) {
-		throw new Exception('Some information is missing.');
-	}
-
 	// rate limiting
-	rate_limit('mod-do-lift-ban-'.$ip, 10, 1);
-	rate_limit('mod-do-lift-ban-'.$ip, 60, 5);
+	rate_limit('mod-do-lift-ban-'.$ip, 5, 2);
 
 	// connect
 	$db = new DB();
@@ -41,16 +35,17 @@ catch(Exception $e) {
 
 try {
 	
+	// sanity check: are any values blank?
+	if(is_empty($ban_id, false) || is_empty($reason)) {
+		throw new Exception('Some information is missing.');
+	}
+	
 	// make some variables
 	$user_id = $mod->user_id;
 	$name = $mod->name;
-	
-	// more rate limiting
-	rate_limit('mod-do-lift-ban-'.$user_id, 10, 1);
-	rate_limit('mod-do-lift-ban-'.$user_id, 60, 5);
 
+	// safety first
 	$safe_name = addslashes($name);
-
 
 	// lift the ban
 	$result = $db->query("UPDATE bans
@@ -80,9 +75,10 @@ try {
 	
 }
 
-catch(Exception $e){
+catch(Exception $e) {
+	$error = $e->getMessage();
 	output_header('Lift Ban', true);
-	echo 'Error: '.$e->getMessage();
+	echo "Error: $error";
 	output_footer();
 }
 

--- a/http_server/www/mod/do_player_search.php
+++ b/http_server/www/mod/do_player_search.php
@@ -13,14 +13,8 @@ try {
 		throw new Exception("Invalid request method.");
 	}
 	
-	// sanity check
-	if(is_empty($name)) {
-		throw new Exception('No username specified.');
-	}
-	
 	// rate limiting
-	rate_limit('mod-do-player-search-'.$ip, 10, 1);
-	rate_limit('mod-do-player-search-'.$ip, 60, 5);
+	rate_limit('mod-do-player-search-'.$ip, 5, 2);
 
 	// connect
 	$db = new DB();
@@ -38,10 +32,10 @@ catch(Exception $e) {
 
 try {
 	
-	// more rate limiting
-	$mod_id = $mod->user_id;
-	rate_limit('mod-do-player-search-'.$mod_id, 10, 1);
-	rate_limit('mod-do-player-search-'.$mod_id, 60, 5);
+	// sanity check
+	if(is_empty($name)) {
+		throw new Exception('No username specified.');
+	}
 
 	// look for a player with provided name
 	$user_id = name_to_id($db, $name);

--- a/http_server/www/mod/lift_ban.php
+++ b/http_server/www/mod/lift_ban.php
@@ -9,8 +9,7 @@ $ip = get_ip();
 try {
 
 	// rate limiting
-	rate_limit('mod-lift-ban-'.$ip, 5, 1);
-	rate_limit('mod-lift-ban-'.$ip, 30, 5);
+	rate_limit('mod-lift-ban-'.$ip, 5, 2);
 	
 	// connect
 	$db = new DB();
@@ -31,11 +30,6 @@ try {
 
 	// output header
 	output_header('Lift Ban', true);
-	
-	// rate limiting
-	$mod_id = $mod->user_id;
-	rate_limit('mod-lift-ban-'.$mod_id, 5, 1);
-	rate_limit('mod-lift-ban-'.$mod_id, 30, 5);
 
 	// get the ban
 	$result = $db->query("SELECT *
@@ -57,8 +51,7 @@ try {
 		throw new Exception('This ban has already been lifted.');
 	}
 
-	// make the visible things
-	
+	// make the visible things...
 	echo "<p>To lift the ban on $banned_name, please enter a reason and hit submit.</p>";
 
 	?>

--- a/http_server/www/mod/mod_log.php
+++ b/http_server/www/mod/mod_log.php
@@ -11,7 +11,7 @@ $ip = get_ip();
 try {
 
 	// rate limiting
-	rate_limit('mod-action-log-'.$ip, 5, 2);
+	rate_limit('mod-action-log-'.$ip, 5, 3);
 	
 	//connect
 	$db = new DB();

--- a/http_server/www/mod/mod_log.php
+++ b/http_server/www/mod/mod_log.php
@@ -11,8 +11,7 @@ $ip = get_ip();
 try {
 
 	// rate limiting
-	rate_limit('mod-action-log-'.$ip, 10, 1);
-	rate_limit('mod-action-log-'.$ip, 30, 2);
+	rate_limit('mod-action-log-'.$ip, 5, 2);
 	
 	//connect
 	$db = new DB();
@@ -30,11 +29,6 @@ catch(Exception $e) {
 }
 
 try {
-	
-	// rate limiting
-	$mod_id = $mod->user_id;
-	rate_limit('mod-action-log-'.$mod_id, 10, 1);
-	rate_limit('mod-action-log-'.$mod_id, 30, 2);
 
 	// get actions for this page
 	$actions = $db->call('mod_actions_select', array($start, $count));

--- a/http_server/www/mod/player_info.php
+++ b/http_server/www/mod/player_info.php
@@ -16,8 +16,7 @@ try {
 	}
 	
 	// rate limiting
-	rate_limit('mod-player-info-'.$mod_ip, 5, 1);
-	rate_limit('mod-player-info-'.$mod_ip, 30, 5);
+	rate_limit('mod-player-info-'.$mod_ip, 5, 2);
 	
 	// connect
 	$db = new DB();
@@ -38,11 +37,6 @@ try {
 	
 	// header
 	output_header('Player Info', true);
-	
-	// rate limiting
-	$mod_id = $mod->user_id;
-	rate_limit('mod-player-info-'.$mod_id, 5, 1);
-	rate_limit('mod-player-info-'.$mod_id, 30, 5);
 
 	//get dem infos
 	$result = $db->query("SELECT pr2.rank, pr2.hat_array, users.power, users.status, users.name, users.ip
@@ -135,6 +129,9 @@ try {
 				."<p>Currently banned: $banned</p>"
 				."<p>IP has been banned $ip_ban_count time$s2.</p> $ip_ban_list";
 	}
+	
+	// footer
+	output_footer();
 }
 
 catch(Exception $e){
@@ -142,7 +139,6 @@ catch(Exception $e){
 	echo "Error: $error";
 	output_footer();
 }
-
 
 
 function create_ban_list($result) {

--- a/http_server/www/mod/player_search.php
+++ b/http_server/www/mod/player_search.php
@@ -9,7 +9,7 @@ $ip = get_ip();
 try {
 
 	// rate limiting
-	rate_limit('mod-player-search-'.$ip, 3, 2);
+	rate_limit('mod-player-search-'.$ip, 5, 3);
 	
 	// connect
 	$db = new DB();

--- a/http_server/www/mod/player_search.php
+++ b/http_server/www/mod/player_search.php
@@ -9,8 +9,7 @@ $ip = get_ip();
 try {
 
 	// rate limiting
-	rate_limit('mod-player-search-'.$ip, 5, 1);
-	rate_limit('mod-player-search-'.$ip, 30, 5);
+	rate_limit('mod-player-search-'.$ip, 3, 2);
 	
 	// connect
 	$db = new DB();
@@ -31,11 +30,6 @@ try {
 	
 	// header
 	output_header('Player Search', true);
-	
-	// rate limiting
-	$mod_id = $mod->user_id;
-	rate_limit('mod-player-search-'.$mod_id, 5, 1);
-	rate_limit('mod-player-search-'.$mod_id, 30, 5);
 
 	// error message
 	if(!is_empty($message)) {
@@ -48,6 +42,9 @@ try {
 		<input type="submit" value="Search" />
 	</form>
 	<?php
+	
+	// footer
+	output_footer();
 
 }
 

--- a/http_server/www/mod/reported_messages.php
+++ b/http_server/www/mod/reported_messages.php
@@ -13,8 +13,7 @@ $mod_ip = get_ip();
 try {
 
 	// rate limiting
-	rate_limit('mod-reported-messages-'.$mod_ip, 10, 1);
-	rate_limit('mod-reported-messages-'.$mod_ip, 60, 5);
+	rate_limit('mod-reported-messages-'.$mod_ip, 5, 3);
 	
 	//connect
 	$db = new DB();
@@ -35,11 +34,6 @@ try {
 	
 	// output header
 	output_header('Reported Messages', true);
-	
-	// more rate limiting
-	$mod_id = $mod->user_id;
-	rate_limit('mod-reported-messages-'.$mod_id, 10, 1);
-	rate_limit('mod-reported-messages-'.$mod_id, 60, 5);
 
 	// navigation
 	output_pagination($start, $count);

--- a/http_server/www/place_artifact.php
+++ b/http_server/www/place_artifact.php
@@ -30,15 +30,15 @@ try {
 	// check their login
 	$user_id = token_login($db);
 	
+	// more rate limiting
+	if ($user_id != 1) {
+		rate_limit( 'place-artifact-'.$ip, 3600, 10, "The artifact can only be placed a maximum of 10 times per hour. Try again later." );
+		rate_limit( 'place-artifact-'.$user_id, 3600, 10, "The artifact can only be placed a maximum of 10 times per hour. Try again later." );
+	}
+	
 	// sanity check: are they Fred?
 	if( $user_id != 1 && $user_id != 4291976 ) {
 		throw new Exception( 'You are not Fred.' );
-	}
-	
-	// more rate limiting
-	rate_limit( 'place-artifact-'.$ip, 3600, 5, "The artifact can only be placed a maximum of 5 times per hour. Try again later." );
-	if ($user_id != 1) {
-		rate_limit( 'place-artifact-'.$user_id, 3600, 5, "The artifact can only be placed a maximum of 5 times per hour. Try again later." );
 	}
 	
 	// update the artifact location in the database

--- a/http_server/www/player_search.php
+++ b/http_server/www/player_search.php
@@ -39,7 +39,7 @@ try {
 	// output functions
 	output_search($name);
 	output_page($user_id);
-	output_footer;
+	output_footer();
 	
 	// seeya
 	die();

--- a/http_server/www/random_level.php
+++ b/http_server/www/random_level.php
@@ -8,7 +8,7 @@ $ip = get_ip();
 try {
 
 	// rate limiting
-	rate_limit('rand_levels-'.$ip, 30, 1, "Please wait at least 30 seconds before generating another random level.");
+	rate_limit('random-level-'.$ip, 10, 1, "Please wait at least 10 seconds before generating another random level.");
 	
 	// connect
 	$db = new DB();

--- a/http_server/www/register_user.php
+++ b/http_server/www/register_user.php
@@ -23,7 +23,7 @@ try {
 	}
 	
 	// rate limiting (check if the IP address is spamming)
-	rate_limit('register-account-attempt-'.$ip, 60, 1, 'Please wait at least one minute before trying to create another account.');
+	rate_limit('register-account-attempt-'.$ip, 10, 2, 'Please wait at least 10 seconds before trying to create another account.');
 
 	// error check
 	if(empty($name) || !is_string($password) || $password == ''){
@@ -42,7 +42,7 @@ try {
 		throw new Exception("'$email' is not a valid email address.");
 	}
 	if(is_obsene($name)){
-		throw new Exception('Do try to think of a different name.');
+		throw new Exception('Keep your username clean, pretty please!');
 	}
 	$test_name = preg_replace("/[^a-zA-Z0-9-.:;=?~! ]/", "", $name);
 	if($test_name != $name){
@@ -63,7 +63,7 @@ try {
 	}
 	
 	// more rate limiting (check if too many accounts have been made from this ip today)
-	rate_limit( 'register-account-'.$ip, 60, 5, 'You may create a maximum of five accounts from the same IP address per day.' );
+	rate_limit('register-account-'.$ip, 86400, 5, 'You may create a maximum of five accounts from the same IP address per day.');
 
 	// everything looks good, so register the user
 	$pass_hash = to_hash($password);
@@ -79,23 +79,6 @@ catch(Exception $e){
 	$ret->error = $e->getMessage();
 	echo json_encode( $ret );
 }
-
-/* OLD RATE LIMITING CODE (remove if not needed and new code works):
-
-	//check if this ip address is spamming
-	$min_time = $time - 60;
-	$register_attempts = $db->grab('register_attempts', 'users_new_select_register_attempts', array($ip, $min_time));
-	if($register_attempts >= 1) {
-		throw new Exception('Please wait at least 60 seconds before trying to create another account.');
-	}
-	//check if too many accounts have been made from this ip today
-	$min_time = $time - (60*60*24);
-	$register_attempts = $db->grab('register_attempts', 'users_new_select_register_attempts', array($ip, $min_time));
-	if($register_attempts >= 5) {
-		throw new Exception('A maximum of five accounts can be created from the same ip address per day.');
-	}
-	
-*/
 
 
 ?>

--- a/http_server/www/remove_friend.php
+++ b/http_server/www/remove_friend.php
@@ -15,8 +15,7 @@ try {
 	}
 	
 	// rate limiting
-	rate_limit('friends-list-'.$ip, 3, 1);
-	rate_limit('friends-list-'.$ip, 30, 5);
+	rate_limit('friends-list-'.$ip, 3, 2);
 	
 	// connect
 	$db = new DB();
@@ -25,8 +24,7 @@ try {
 	$user_id = token_login($db, false);
 	
 	// more rate limiting
-	rate_limit('friends-list-'.$user_id, 3, 1);
-	rate_limit('friends-list-'.$user_id, 30, 5);
+	rate_limit('friends-list-'.$user_id, 3, 2);
 	
 	// get the id of the player they're removing as a friend
 	$friend_id = name_to_id($db, $friend_name);

--- a/http_server/www/staff.php
+++ b/http_server/www/staff.php
@@ -10,7 +10,7 @@ output_header('PR2 Staff Team');
 try {
 	
 	// rate limiting
-	rate_limit('gui-staff-list-'.$ip, 10, 1, 'Please wait at least 10 seconds before refreshing the page again.');
+	rate_limit('gui-staff-list-'.$ip, 5, 2, 'Please wait at least 10 seconds before refreshing the page again.');
 	
 	// connect
 	$db = new DB();

--- a/http_server/www/submit_rating.php
+++ b/http_server/www/submit_rating.php
@@ -23,7 +23,6 @@ try {
 	
 	// rate limiting
 	rate_limit('submit-rating-'.$ip, 5, 1);
-	rate_limit('submit-rating-'.$ip, 30, 5);
 	
 	// sanity check: is the rating valid?
 	$new_rating = round($new_rating);
@@ -38,8 +37,7 @@ try {
 	$user_id = token_login($db, false);
 	
 	// rate limiting
-	rate_limit('submit-rating-'.$ip, 5, 1);
-	rate_limit('submit-rating-'.$ip, 30, 5);
+	rate_limit('submit-rating-'.$user_id, 5, 1);
 
 	// see if they made this level
 	$result = $db->query("SELECT level_id

--- a/http_server/www/submit_rating.php
+++ b/http_server/www/submit_rating.php
@@ -22,7 +22,7 @@ try {
 	}
 	
 	// rate limiting
-	rate_limit('submit-rating-'.$ip, 5, 1);
+	rate_limit('submit-rating-'.$ip, 5, 2);
 	
 	// sanity check: is the rating valid?
 	$new_rating = round($new_rating);

--- a/http_server/www/submit_rating.php
+++ b/http_server/www/submit_rating.php
@@ -37,7 +37,7 @@ try {
 	$user_id = token_login($db, false);
 	
 	// rate limiting
-	rate_limit('submit-rating-'.$user_id, 5, 1);
+	rate_limit('submit-rating-'.$user_id, 5, 2);
 
 	// see if they made this level
 	$result = $db->query("SELECT level_id

--- a/http_server/www/un_ignore_user.php
+++ b/http_server/www/un_ignore_user.php
@@ -15,8 +15,7 @@ try {
 	}
 	
 	// rate limiting
-	rate_limit('ignored-list-'.$ip, 3, 1);
-	rate_limit('ignored-list-'.$ip, 30, 5);
+	rate_limit('ignored-list-'.$ip, 3, 2);
 	
 	// connect
 	$db = new DB();
@@ -25,8 +24,7 @@ try {
 	$user_id = token_login($db, false);
 	
 	// more rate limiting
-	rate_limit('ignored-list-'.$user_id, 3, 1);
-	rate_limit('ignored-list-'.$user_id, 30, 5);
+	rate_limit('ignored-list-'.$user_id, 3, 2);
 	
 	// get the id of the un-ignored player
 	$target_id = name_to_id($db, $target_name);


### PR DESCRIPTION
I made the rate-limiting a little more relaxed since it's extremely obnoxious right now.  Don't worry, it should still protect against attacks.  I think the lowest limit I made was `rate_limit($key, 3, 2)`.

Additionally, some of the little changes that were made:
 - Fixed submit_rating.php
 - Hopefully fixed player_search.php
 - Fixed remember me and added a third-party domain warning on login (login.php)
 - Hopefully fixed search_by_email.php
 - Added footers to mod files that were missing them
 - Added pagination and count restriction for non-mods to bans.php
 - Was able to force POST requests only in some mod files

LMK what you think!