### PR TITLE
Fixes/additions to http_server and multiplayer_server

### DIFF
--- a/http_server/cron/fah_award_prizes.php
+++ b/http_server/cron/fah_award_prizes.php
@@ -2,7 +2,6 @@
 
 require_once(__DIR__ . '/../fns/all_fns.php');
 
-
 $prize_array = array();
 $processed_names = array();
 $name_switch_array = array();
@@ -15,9 +14,9 @@ $pr2_db = new DB();
 
 
 //--- create a list of existing users and their prizes --------------------------------------------------
-$result = $pr2_db->query('select folding_at_home.*, users.name, users.status
-							 	from folding_at_home, users
-								where folding_at_home.user_id = users.user_id');
+$result = $pr2_db->query('SELECT folding_at_home.*, users.name, users.status
+							 	FROM folding_at_home, users
+								WHERE folding_at_home.user_id = users.user_id');
 
 while($row = $result->fetch_object()) {
 	$prize_array[strtolower($row->name)] = $row;
@@ -26,29 +25,29 @@ while($row = $result->fetch_object()) {
 
 
 //--- create a list of name switches --------------------------------------------------------------------
-$result = $fah_db->call( 'pr2_name_links_select' );
-while( $row = $result->fetch_object() ) {
-	$name_switch_array[ strtolower($row->fah_name) ] = strtolower( $row->pr2_name );
+$result = $fah_db->call('pr2_name_links_select');
+while($row = $result->fetch_object()) {
+	$name_switch_array[strtolower($row->fah_name)] = strtolower($row->pr2_name);
 }
 
 
 
 //--- get fah user stats -------------------------------------------------------------------------------
-$result = $fah_db->call( 'stats_select_all' );
-while( $user = $result->fetch_object() ) {
-	add_prizes( $pr2_db, $user->fah_name, $user->points, $prize_array, $processed_names );
+$result = $fah_db->call('stats_select_all');
+while($user = $result->fetch_object()) {
+	add_prizes($pr2_db, $user->fah_name, $user->points, $prize_array, $processed_names);
 }
 
 
 
-function add_prizes( $db, $name, $score, $prize_array, $processed_names ){
+function add_prizes($db, $name, $score, $prize_array, $processed_names) {
 	$name = replace_name($name);
-	$lower_name = strtolower( $name );
+	$lower_name = strtolower($name);
 
 	if(!isset($processed_names[$lower_name])) {
 		$processed_names[$lower_name] = 1;
 
-		try{
+		try {
 
 			if(isset($prize_array[$lower_name])) {
 				$row = $prize_array[$lower_name];
@@ -57,36 +56,25 @@ function add_prizes( $db, $name, $score, $prize_array, $processed_names ){
 			}
 
 			else {
-				//grab their user id
-				$safe_name = $db->real_escape_string($name);
-				$result = $db->query("select user_id, status
-												from users
-												where name = '$safe_name'
-												limit 0, 1");
-				if(!$result){
-					throw new Exception("Could not retrieve $name's user id.");
-				}
-				if($result->num_rows <= 0){
-					throw new Exception("$name is not a registered user.");
-				}
-				$row = $result->fetch_object();
-				$user_id = $row->user_id;
-				$status = $row->status;
+				// convert name to user ID
+				$user_id = name_to_id($db, $name);
+				$user = $db->grab_row('user_select', array($user_id), 'Could not find a user with that ID.');
+				
+				// make some variables
+				$user_id = (int) $user->user_id;
+				$status = $user->status;
 
-
-				//grab their F@H record
-				$safe_user_id = $db->real_escape_string($user_id);
-				$result = $db->query("select *
-												from folding_at_home
-												where user_id = '$safe_user_id'
-												limit 0, 1");
-				if(!$result){
+				// grab their F@H record
+				$record = $db->query("SELECT * 
+								FROM folding_at_home
+								WHERE user_id = '$user_id'
+								LIMIT 0, 1");
+				if(!$record) {
 					throw new Exception("Could not retrieve $name's F@H record.");
 				}
-				if($result->num_rows <= 0){
-					//create a new F@H record for them if they don't have one
-					$add_result = $db->query("insert into folding_at_home
-														set user_id = '$safe_user_id'");
+				if($record->num_rows <= 0) {
+					// create a new F@H record for them if they don't have one
+					$add_result = $db->query("INSERT INTO folding_at_home SET user_id = '$user_id'");
 					if(!$add_result){
 						throw new Exception("Could not create $name's F@H record.");
 					}
@@ -94,11 +82,11 @@ function add_prizes( $db, $name, $score, $prize_array, $processed_names ){
 					$db->call('message_insert', array($user_id, 1, $message, '0'));
 					throw new Exception("Successfully created $name's F@H record.");
 				}
-				$row = $result->fetch_object();
+				$row = $record->fetch_object();
 			}
 
-			if($status != 'offline'){
-				throw new Exception("We'll do this later, because $name is not offline. They are '$status'.");
+			if($status != 'offline') {
+				throw new Exception("$name is \"$status\". Abort mission! We'll try again later.");
 			}
 
 			//3 rank in pr2
@@ -110,15 +98,17 @@ function add_prizes( $db, $name, $score, $prize_array, $processed_names ){
 			award_prize($db, $user_id, $name, $score, $row, 'crown_hat', 5000, 'Crown Hat in Platform Racing 2');
 
 			//cowboy hat
-			award_prize($db, $user_id, $name, $score, $row, 'cowboy_hat', 100000, 'Super Flying Cowboy Hat in PlatformRacing 2');
+			award_prize($db, $user_id, $name, $score, $row, 'cowboy_hat', 100000, 'Super Flying Cowboy Hat in Platform Racing 2');
 
 			//some more rank tokens
 			award_prize($db, $user_id, $name, $score, $row, 'r4', 1000000, '+1 rank increase in Platform Racing 2');
 			award_prize($db, $user_id, $name, $score, $row, 'r5', 10000000, '+1 rank increase in Platform Racing 2');
 
 		}
-		catch(Exception $e){
-			//output( $e->getMessage() );
+		catch(Exception $e) {
+			$error = $e->getMessage();
+			$safe_error = htmlspecialchars($error);
+			output($safe_error);
 		}
 	}
 }
@@ -126,13 +116,13 @@ function add_prizes( $db, $name, $score, $prize_array, $processed_names ){
 
 
 function award_prize($db, $user_id, $name, $score, $row, $db_val, $min_score, $prize_str){
-	if($score >= $min_score && $row->{$db_val} != 1){
+	if($score >= $min_score && $row->{$db_val} != 1) {
 
-		output( "awarding $db_val to $name" );
+		output("awarding $db_val to $name");
 		$row->{$db_val} = 1;
 
 		//give the prize
-		$safe_user_id = $db->real_escape_string($user_id);
+		$user_id = (int) $user_id;
 		if($db_val == 'r1' || $db_val == 'r2' || $db_val == 'r3' || $db_val == 'r4' || $db_val == 'r5') {
 			if($db_val == 'r1') {
 				$tokens = 1;
@@ -174,11 +164,11 @@ function award_prize($db, $user_id, $name, $score, $row, $db_val, $min_score, $p
 		$db->call('message_insert', array($user_id, 1, $message, '0'));
 		
 		//remember that this prize has been given
-		$result = $db->query("update folding_at_home
-										set $db_val = 1
-										where user_id = '$safe_user_id'
-										limit 1");
-		if(!$result){
+		$result = $db->query("UPDATE folding_at_home
+								SET $db_val = 1
+								WHERE user_id = '$user_id'
+								LIMIT 1");
+		if(!$result) {
 			throw new Exception("Could not update $db_val status for $name.");
 		}
 	}
@@ -186,12 +176,12 @@ function award_prize($db, $user_id, $name, $score, $row, $db_val, $min_score, $p
 
 
 
-function replace_name($name){
+function replace_name($name) {
 	global $name_switch_array;
 	$name = str_replace('_', ' ', $name);
-	if( isset( $name_switch_array[strtolower($name)] ) ) {
+	if(isset($name_switch_array[strtolower($name)])) {
 		$new_name = $name_switch_array[strtolower($name)];
-		output( "replacing $name with $new_name" );
+		output("replacing $name with $new_name");
 		$name = $new_name;
 	}
 	return $name;
@@ -203,8 +193,8 @@ function replace_name($name){
 
 
 //--- handy output function; never leave home without it! --------------------------------------------------
-function output( $str ) {
-	echo( "* $str \n" );
+function output($str) {
+	echo("* $str \n");
 }
 
 ?>

--- a/http_server/www/admin/search_by_email.php
+++ b/http_server/www/admin/search_by_email.php
@@ -58,7 +58,7 @@ try {
 							");
 	$row_count = $result->num_rows;
 	if ($row_count <= 0) {
-		throw new Exception("No accounts found with the email address '$safe_email'.");
+		throw new Exception("No accounts found with the email address \"$safe_email\".");
 	}
 	
 	// protect the user
@@ -66,6 +66,15 @@ try {
   
 	// show the search form
 	output_search($disp_email);
+	
+	// output the number of results
+	if($row_count == 1) {
+		$res = 'result';
+	}
+	else {
+		$res = 'results';
+	}
+	echo "$row_count $res found for the email address \"$disp_email\".<br><br>";
 	
 	// only gonna get here if there were results
 	while ($row = $result->fetch_object()) {
@@ -79,6 +88,9 @@ try {
 		$active_date = $row->active_date; // active date -- get data
 		$active_date = date_create($active_date); // active date -- create a date
 		$active_date = date_format($active_date, 'j/M/Y'); // active date -- format the created date
+		if ($active_date == '30/Nov/-0001') {
+			$active_date = 'Never';
+		}
 
 		// display the name with the color and link to the player search page
 		echo "<a href='player_deep_info.php?name1=$url_name' style='color: #$group_color; text-decoration: underline;'>$safe_name</a> | Last Active: $active_date<br>";

--- a/http_server/www/admin/update_account.php
+++ b/http_server/www/admin/update_account.php
@@ -36,6 +36,9 @@ try {
 
 	// update
 	if($action === 'update') {
+		if($_SERVER['REQUEST_METHOD'] !== 'POST') {
+			throw new Exception('Invalid request type.');
+		}
 		update($db);
 	}
 	
@@ -48,7 +51,7 @@ try {
 // page
 function output_form($db, $user_id) {
 
-	echo '<form name="input" action="update_account.php" method="get">';
+	echo '<form name="input" action="update_account.php" method="post">';
 
 	$user = $db->grab_row('user_select', array($user_id));
 	$pr2 = $db->grab_row('pr2_select', array($user->user_id), '', true);

--- a/http_server/www/admin/update_account.php
+++ b/http_server/www/admin/update_account.php
@@ -62,10 +62,12 @@ function output_form($db, $user_id) {
 	echo 'Name: <input type="text" size="" name="name" value="'.htmlspecialchars($user->name).'"><br>';
 	echo 'Email: <input type="text" name="email" value="'.htmlspecialchars($user->email).'"><br>';
 	echo 'Guild: <input type="text" name="guild" value="'.htmlspecialchars($user->guild).'"><br>';
-	echo 'Hats: <input type="text" size="100" name="hats" value="'.$pr2->hat_array.'"><br>';
-	echo 'Heads: <input type="text" size="100" name="heads" value="'.$pr2->head_array.'"><br>';
-	echo 'Bodies: <input type="text" size="100" name="bodies" value="'.$pr2->body_array.'"><br>';
-	echo 'Feet: <input type="text" size="100" name="feet" value="'.$pr2->feet_array.'"><br>';
+	if($pr2) {
+		echo 'Hats: <input type="text" size="100" name="hats" value="'.$pr2->hat_array.'"><br>';
+		echo 'Heads: <input type="text" size="100" name="heads" value="'.$pr2->head_array.'"><br>';
+		echo 'Bodies: <input type="text" size="100" name="bodies" value="'.$pr2->body_array.'"><br>';
+		echo 'Feet: <input type="text" size="100" name="feet" value="'.$pr2->feet_array.'"><br>';
+	}
 	if($pr2_epic) {
 		echo 'Epic Hats: <input type="text" size="100" name="eHats" value="'.$pr2_epic->epic_hats.'"><br>';
 		echo 'Epic Heads: <input type="text" size="100" name="eHeads" value="'.$pr2_epic->epic_heads.'"><br>';
@@ -102,7 +104,18 @@ function update($db) {
 	// call user information
 	$user = $db->grab_row('user_select', array($user_id));
 	$user_name = $user->name;
-
+	
+	// adjust guild member count
+	if($user->guild != $guild_id) {
+		if ($user->guild != 0) {
+			$db->call('guild_increment_member', array($user->guild, -1));
+		}
+		if ($guild_id != 0) {
+			$db->call('guild_increment_member', array($guild_id, 1));
+		}
+	}
+	
+	// email change logging
 	if($user->email !== $email) {
 		$code = 'manual-' . time();
 		$db->call('changing_email_insert', array($user_id, $user->email, $email, $code, ''));

--- a/http_server/www/admin/update_account.php
+++ b/http_server/www/admin/update_account.php
@@ -53,7 +53,7 @@ function output_form($db, $user_id) {
 
 	echo '<form name="input" action="update_account.php" method="post">';
 
-	$user = $db->grab_row('user_select', array($user_id));
+	$user = $db->grab_row('user_select', array($user_id), 'Could not find a user with that ID.');
 	$pr2 = $db->grab_row('pr2_select', array($user->user_id), '', true);
 	$pr2_epic = $db->grab_row('epic_upgrades_select', array($user->user_id), '', true);
 	echo "user_id: $user->user_id <br>---<br>";

--- a/http_server/www/bans/bans.php
+++ b/http_server/www/bans/bans.php
@@ -25,7 +25,7 @@ try {
 	
 	if ($is_mod === false) {
 		rate_limit('list-bans-'.$ip, 60, 10);
-		if ($count - $start > 100) {
+		if (($count - $start) > 100) {
 			$count = $start + 100;
 		}
 	}

--- a/http_server/www/guild_join.php
+++ b/http_server/www/guild_join.php
@@ -3,7 +3,7 @@
 header("Content-type: text/plain");
 require_once('../fns/all_fns.php');
 
-$guild_id = find('guildId');
+$guild_id = (int) find_no_cookie('guildId', 0);
 $ip = get_ip();
 
 try {
@@ -17,14 +17,14 @@ try {
 	// gather information
 	$user_id = token_login($db, false);
 	$account = $db->grab_row('user_select_expanded', array($user_id));
-	$guild = $db->grab_row('guild_select', array($guild_id));
+	$guild = $db->grab_row('guild_select', array($guild_id), 'Could not find a guild with that ID.');
 	
 	// sanity checks
 	if($account->guild != 0) {
 		throw new Exception('You are already a member of a guild.');
 	}
 	if($account->power <= 0) {
-                throw new Exception('Guests can not join guilds.');
+                throw new Exception('Guests can\'t join guilds.');
 	}
 	if($guild->member_count >= 200) {
 		throw new Exception('This guild is full.');

--- a/http_server/www/login.php
+++ b/http_server/www/login.php
@@ -86,15 +86,15 @@ try {
 
 
 	//--- get the server they're connecting to
-	$server = $db->grab_row( 'server_select', array( $server_id ) );
+	$server = $db->grab_row('server_select', array($server_id));
 
 
 
 	//--- guest login
-	if( strtolower($login->user_name) == 'guest' ) {
+	if( strtolower(trim($login->user_name)) == 'guest' ) {
 		$guest_login = true;
 		if( get_ip(false) != get_ip(true) ) {
-			throw new Exception( 'You seem to be using a proxy to connect to PR2. You won\'t be able to connect as a guest, but you can create an account to play.' );
+			throw new Exception( "You seem to be using a proxy to connect to PR2. You won't be able to connect as a guest, but you can create an account to play." );
 		}
 		$user = $db->grab_row('users_select_guest');
 		check_if_banned($db, $user->user_id, $ip);
@@ -133,10 +133,20 @@ try {
 	}
 
 
-	//--
+	// create variables from user data in db
 	$user_id = $user->user_id;
 	$user_name = $user->name;
+	$login->user_name = $user_name; // sanitize user input by taking name from the db to send to the server
 	$group = $user->power;
+	
+	
+	// name sanity checks
+	if (strlen(trim($user_name)) < 2) {
+		throw new Exception("Your name must be at least 2 characters long.");
+	}
+	if (strlen(trim($user_name)) > 20) {
+		throw new Exception("Your name cannot be more than 20 characters long.");
+	}
 
 
 	//---

--- a/http_server/www/login.php
+++ b/http_server/www/login.php
@@ -165,20 +165,17 @@ try {
 		$new_account = 'true';
 		$db->call('pr2_insert', array($user_id));
 
-		//--- send them a welcome pm
-		$welcome_message = 'Welcome to Platform Racing 2, '.$user_name.'!
-
-<a href="https://grahn.io" target="_blank"><u><font color="#0000FF">Click here</font></u></a> to read about the latest Platform Racing news on my blog.
-
-If you have any questions or comments, send me an email at <a href="mailto:jacob@grahn.io?subject=Questions or Comments about PR2" target="_blank"><u><font color="#0000FF">jacob@grahn.io</font></u></a>.
-
-Thanks for playing, I hope you enjoy.
-
-- Jacob';
+		// compose a welcome pm
+		$welcome_message = "Welcome to Platform Racing 2, $user_name!\n\n"
+					."<a href='https://grahn.io' target='_blank'><u><font color='#0000FF'>Click here</font></u></a> to read about the latest Platform Racing news on my blog.\n\n"
+					."If you have any questions or comments, send me an email at <a href='mailto:jacob@grahn.io?subject=Questions or Comments about PR2' target='_blank'><u><font color='#0000FF'>jacob@grahn.io</font></u></a>.\n\n"
+					."Thanks for playing, I hope you enjoy.\n\n"
+					."- Jacob";
 		
+		// send the welcome PM
 		$db->call('message_insert', array($user_id, 1, $welcome_message, '0'));
 
-		//--- I don't feel like typing the defaults twice, so pull them from the db
+		// I don't feel like typing the defaults twice, so pull them from the db
 		$pr2_result = $db->call('pr2_select', array($user_id));
 	}
 

--- a/http_server/www/player_search.php
+++ b/http_server/www/player_search.php
@@ -38,7 +38,7 @@ try {
 	
 	// output functions
 	output_search($name);
-	output_page($user_id);
+	output_page($db, $user_id);
 	output_footer();
 	
 	// seeya
@@ -73,7 +73,7 @@ function output_error($error='') {
 	}
 }
 
-function output_page($user_id) {
+function output_page($db, $user_id) {
 	
 	// prepare the user id
 	$user_id = (int) $user_id;

--- a/http_server/www/register_user.php
+++ b/http_server/www/register_user.php
@@ -64,9 +64,25 @@ try {
 	// more rate limiting (check if too many accounts have been made from this ip today)
 	rate_limit('register-account-'.$ip, 86400, 5, 'You may create a maximum of five accounts from the same IP address per day.');
 
-	// everything looks good, so register the user
+	// --- begin user registration --- \\
+	
+	// user insert
 	$pass_hash = to_hash($password);
 	$db->call('user_insert', array($name, $pass_hash, $ip, $time, $email));
+	
+	// pr2 insert
+	$user_id = name_to_id($db, $name);
+	$db->call('pr2_insert', array($user_id));
+
+	// compose a welcome pm
+	$welcome_message = "Welcome to Platform Racing 2, $user_name!\n\n"
+				."<a href='https://grahn.io' target='_blank'><u><font color='#0000FF'>Click here</font></u></a> to read about the latest Platform Racing news on my blog.\n\n"
+				."If you have any questions or comments, send me an email at <a href='mailto:jacob@grahn.io?subject=Questions or Comments about PR2' target='_blank'><u><font color='#0000FF'>jacob@grahn.io</font></u></a>.\n\n"
+				."Thanks for playing, I hope you enjoy.\n\n"
+				."- Jacob";
+	
+	// welcome them
+	$db->call('message_insert', array($user_id, 1, $welcome_message, '0'));
 
 	$ret = new stdClass();
 	$ret->result = 'success';

--- a/http_server/www/register_user.php
+++ b/http_server/www/register_user.php
@@ -29,10 +29,10 @@ try {
 	if(empty($name) || !is_string($password) || $password == ''){
 		throw new Exception('You must enter a name and a password to register an account.');
 	}
-	if(strlen($name) < 2){
+	if(trim(strlen($name)) < 2){
 		throw new Exception('Your name must be at least 2 characters long.');
 	}
-	if(strlen($name) > 20){
+	if(trim(strlen($name)) > 20){
 		throw new Exception('Your name can not be more than 20 characters long.');
 	}
 	if(strpos($name, '`') !== false){

--- a/multiplayer_server/Player.php
+++ b/multiplayer_server/Player.php
@@ -457,13 +457,77 @@ class Player {
 				}
 				
 				if ($chat_message == '/debug help') {
-					$this->write("systemChat`Acceptable Arguments:<br><br>- restart_server<br>- server");
+					$this->write("systemChat`Acceptable Arguments:<br><br>- help<br>- player *name*<br>- restart_server<br>- server");
 				}
 				else if ($chat_message == '/debug restart_server') {
 					$this->write("message`chat_message: $chat_message<br>admin_name: $admin_name<br>admin_id: $admin_id<br>ip: $ip<br>server_name: $server_name<br>server_id: $server_id<br>port: $port");
 				}
 				else if ($chat_message == '/debug server') {
 					$this->write("message`chat_message: $chat_message<br>port: $port<br>server_name: $server_name<br>server_id: $server_id<br>uptime: $uptime<br>private_server: $is_ps<br>server_guild: $guild_id<br>server_owner: $guild_owner<br>server_expire_time: $server_expire_time");
+				}
+				else if (strpos($chat_message, '/debug player ') === 0) {
+					$player_name = trim(substr($chat_message, 14));
+					$player_id = name_to_id($db, $player_name);
+					$player = id_to_player($player_id);
+					
+					if(isset($player)) {
+						$pip = $player->ip;
+						$pname = $player->name;
+						$puid = $player->user_id;
+						$pstatus = $player->status;
+						$pgroup = $player->group;
+						$pguild = $player->guild_id;
+						$parank = $player->active_rank;
+						$prank = $player->rank;
+						$prtused = $player->rt_used;
+						$prtavail = $player->rt_available;
+						$pexp2day = $player->exp_today;
+						$pexppoints = $player->exp_points;
+						$pspeed = $player->speed;
+						$paccel = $player->acceleration;
+						$pjump = $player->jumping;
+						$phat = $player->hat;
+						$phead = $player->head;
+						$pbody = $player->body;
+						$pfeet = $player->feet;
+						$phatc = $player->hat_color;
+						$pheadc = $player->head_color;
+						$pbodyc = $player->body_color;
+						$pfeetc = $player->feet_color;
+						$pehatc = $player->hat_color_2;
+						$peheadc = $player->head_color_2;
+						$pebodyc = $player->body_color_2;
+						$pefeetc = $player->feet_color_2;
+						$pdomain = $player->domain;
+						$pversion = $player->version;
+						if ($player->temp_mod === true) {
+							$ptemp = 'yes';
+						}
+						else {
+							$ptemp = 'no';
+						}
+						
+						$this->write("message`"
+								."chat_message: $chat_message<br>"
+								."ip: $pip<br>"
+								."name: $pname | user_id: $puid<br>"
+								."status: $pstatus<br>"
+								."group: $pgroup | temp_mod: $ptemp<br>"
+								."guild_id: $pguild<br>"
+								."active_rank: $parank | rank (no rt): $prank | rt_used: $prtused | rt_avail: $prtavail<br>"
+								."exp_today: $pexp2day | exp_points: $pexppoints<br>"
+								."speed: $pspeed | acceleration: $paccel | jumping: $pjump<br>"
+								."hat: $phat | head: $phead | body: $pbody | feet: $pfeet<br>"
+								."hat_color: $phatc | hat_color_2: $pehatc<br>"
+								."head_color: $pheadc | head_color_2: $peheadc<br>"
+								."body_color: $pbodyc | body_color_2: $pebodyc<br>"
+								."feet_color: $pfeetc | feet_color_2: $pefeetc<br>"
+								."domain: $pdomain<br>"
+								."version: $pversion");
+					}
+					else {
+						$this->write('message`Error: Could not find a player with that name on this server.');
+					}
 				}
 				else {
 					$this->write("systemChat`Enter an argument to get the data you want. For a list of acceptable arguments, type /debug help.");

--- a/multiplayer_server/fns/utils.php
+++ b/multiplayer_server/fns/utils.php
@@ -17,7 +17,7 @@ function send_to_guild( $guild_id, $str ) {
 }
 
 // limit the amount of times an action can be performed in a certain time period
-function rate_limit($key, $interval, $max, $display_error=false, $player, $error='Slow down a bit, yo.') {
+function rate_limit($key, $interval, $max, $display_error=false, $player=NULL, $error='Slow down a bit, yo.') {
 	$unit = round(time() / $interval);
 	$key .= '-'.$unit;
 	$count = 0;
@@ -25,7 +25,7 @@ function rate_limit($key, $interval, $max, $display_error=false, $player, $error
 		$count = apcu_fetch( $key );
 		if( $count >= $max ) {
 			output("$key triggered rate limit");
-			if ($display_error === true) {
+			if ($display_error === true && $player != NULL) {
 				$player->write("message`Error: $error");
 			}
 		}

--- a/multiplayer_server/fns/utils.php
+++ b/multiplayer_server/fns/utils.php
@@ -7,7 +7,6 @@ function send_to_all_players( $str ) {
 	}
 }
 
-
 function send_to_guild( $guild_id, $str ) {
 	global $player_array;
 	foreach( $player_array as $player ) {
@@ -15,6 +14,37 @@ function send_to_guild( $guild_id, $str ) {
 			$player->write( $str );
 		}
 	}
+}
+
+// limit the amount of times an action can be performed in a certain time period
+function rate_limit($key, $interval, $max, $display_error=false, $player, $error='Slow down a bit, yo.') {
+	$unit = round(time() / $interval);
+	$key .= '-'.$unit;
+	$count = 0;
+	if( apcu_exists($key) ) {
+		$count = apcu_fetch( $key );
+		if( $count >= $max ) {
+			output("$key triggered rate limit");
+			if ($display_error === true) {
+				$player->write("message`Error: $error");
+			}
+		}
+	}
+	$count++;
+	apcu_store( $key, $count, $interval );
+	return( $count );
+}
+
+//--- takes an id and returns a name -----------------------------------------
+function id_to_name($db, $user_id) {
+	$user_name = $db->grab('name', 'user_select', array($user_id));
+	return $user_name;
+}
+
+//--- takes a name and returns an id -----------------------------------------
+function name_to_id($db, $name) {
+	$user_id = $db->grab('user_id', 'user_select_user_id', array($name), 'Could not find a user with that name.');
+	return $user_id;
 }
 
 
@@ -30,7 +60,7 @@ function id_to_player($id, $throw_exception=true){
 
 
 
-//--- takes a name and returns a player -----------------------------------------
+//--- takes a name and returns a player --------------------------------------
 function name_to_player($name){
 	global $player_array;
 	$return_player = NULL;
@@ -45,7 +75,7 @@ function name_to_player($name){
 
 
 
-//--- checks to see if an ip is banned ------------------------------------------
+//--- checks to see if an ip is banned ---------------------------------------
 function get_banned_ip($ip){
 	global $banned_ip_array;
 	$banned_ip = @$banned_ip_array[$ip];
@@ -70,7 +100,7 @@ function get_login_id(){
 }
 
 
-//--- get an existing chat room, or make a new one ---------------------------------------
+//--- get an existing chat room, or make a new one --------------------------
 function get_chat_room($chat_room_name){
 	global $chat_room_array;
 	if(isset($chat_room_array[$chat_room_name])){
@@ -83,7 +113,7 @@ function get_chat_room($chat_room_name){
 }
 
 
-//--- accept bans from other servers ----------------------------------------------------
+//--- accept bans from other servers ----------------------------------------
 function apply_bans( $bans ){
 	global $player_array;
 	
@@ -98,7 +128,7 @@ function apply_bans( $bans ){
 
 
 
-//--- send new pm notifications out ----------------------------------------------------
+//--- send new pm notifications out -----------------------------------------
 function pm_notify( $pms ){
 	global $player_array;
 

--- a/multiplayer_server/process/register_login.php
+++ b/multiplayer_server/process/register_login.php
@@ -2,62 +2,66 @@
 
 //--- creates a player if the log in was successful -----------------------
 function process_register_login ($server_socket, $data) {
-  if ($server_socket->process == true) {
-  	global $login_array;
-  	global $player_array;
-  	global $guild_id;
-  	global $guild_owner;
+	if ($server_socket->process == true) {
+		global $login_array;
+		global $player_array;
+		global $guild_id;
+		global $guild_owner;
 
-  	$login_obj = json_decode( $data );
-  	$login_id = $login_obj->login->login_id;
-  	$group = $login_obj->user->power;
-  	$user_id = $login_obj->user->user_id;
+		$login_obj = json_decode( $data );
+		$login_id = $login_obj->login->login_id;
+		$group = $login_obj->user->power;
+		$user_id = $login_obj->user->user_id;
 
-  	$socket = @$login_array[$login_id];
-  	unset($login_array[$login_id]);
+		$socket = @$login_array[$login_id];
+		unset($login_array[$login_id]);
 
-  	if (isset($socket)) {
+		if (isset($socket)) {
 
-      if (!$server_socket->process) {
-        $socket->write('message`Login verify failed.');
-  			$socket->close();
-  			$socket->on_disconnect();
-      }
+			if (!$server_socket->process) {
+				$socket->write('message`Login verify failed.');
+				$socket->close();
+				$socket->on_disconnect();
+			}
 
-  		else if( $guild_id != 0 && $guild_id != $login_obj->user->guild ) {
-  			$socket->write('message`You are not a member of this guild.');
-  			$socket->close();
-  			$socket->on_disconnect();
-  		}
+			else if( $guild_id != 0 && $guild_id != $login_obj->user->guild ) {
+				$socket->write('message`You are not a member of this guild.');
+				$socket->close();
+				$socket->on_disconnect();
+			}
 
-  		else if(isset($player_array[$user_id])){
-  			$existing_player = $player_array[$user_id];
-  			$existing_player->write('message`You were disconnected because you logged in somewhere else.');
-  			$existing_player->remove();
+			else if(isset($player_array[$user_id])){
+				$existing_player = $player_array[$user_id];
+				$existing_player->write('message`You were disconnected because you logged in somewhere else.');
+				$existing_player->remove();
 
-  			$socket->write('message`Your account was already running on this server. It has been logged out to save your data. Please log in again.');
-  			$socket->close();
-  			$socket->on_disconnect();
-  		}
+				$socket->write('message`Your account was already running on this server. It has been logged out to save your data. Please log in again.');
+				$socket->close();
+				$socket->on_disconnect();
+			}
 
-  		else if( LocalBans::is_banned($login_obj->user->name) ) {
-  			$socket->write('message`You have been kicked from this server for 30 minutes.');
-  			$socket->close();
-  			$socket->on_disconnect();
-  		}
+			else if( LocalBans::is_banned($login_obj->user->name) ) {
+				$socket->write('message`You have been kicked from this server for 30 minutes.');
+				$socket->close();
+				$socket->on_disconnect();
+			}
 
-  		else {
-  			$player = new Player( $socket, $login_obj );
-  			$socket->player = $player;
-  			if( $player->user_id == $guild_owner ) {
-  				$player->become_temp_mod();
-  			}
-  			$socket->write('loginSuccessful`'.$group);
-  			$socket->write('setRank`'.$player->active_rank);
-  			$socket->write( 'ping`' . time() );
-  		}
-  	}
-  }
+			else {
+				$player = new Player($socket, $login_obj);
+				$socket->player = $player;
+				if($player->user_id == $guild_owner && $guild_owner != 4291976) {
+					$player->become_temp_mod();
+				}
+				else if($player->user_id == $guild_owner && $guild_owner == 4291976) {
+					$player->become_server_owner();
+				}
+				
+				$socket->write('loginSuccessful`'.$group);
+				$socket->write('setRank`'.$player->active_rank);
+				$socket->write( 'ping`' . time() );
+			}
+		}
+	}
 }
 
 ?>

--- a/multiplayer_server/rooms/Game.php
+++ b/multiplayer_server/rooms/Game.php
@@ -129,6 +129,11 @@ class Game extends Room {
 	private function record_plays() {
 		global $play_count_array;
 		$player_count = count($this->player_array);
+		foreach($this->player_array as $player){
+			$level_id = $this->course_id;
+			$user_id = $player->user_id;
+			rate_limit("level-play-count-$level_id-$user_id", 3600, 50);
+		}
 		if(isset($play_count_array[$this->course_id])){
 			$play_count_array[$this->course_id] += $player_count;
 		}

--- a/multiplayer_server/rooms/Game.php
+++ b/multiplayer_server/rooms/Game.php
@@ -517,10 +517,16 @@ class Game extends Room {
 				$player->write('award`Defeated '.$race_stats->name.'`+ '.$exp_gain);
 			}
 
+			// hat, campaign, hh bonuses
 			$hat_bonus = 0;
 			foreach($player->worn_hat_array as $hat) {
 				if($hat->num == 2){
-					$hat_bonus += 1;
+					if (isset($this->campaign)) {
+						$hat_bonus += .4;
+					}
+					else if(!isset($this->campaign)) {
+						$hat_bonus += 1;
+					}
 				}
 				else if($hat->num == 3){
 					$hat_bonus += .25;
@@ -531,7 +537,6 @@ class Game extends Room {
 			}
 			if($hat_bonus > 0){
 				$tot_exp_gain += $tot_exp_gain * $hat_bonus;
-				$player->write('award`Hat Bonus`exp X '.($hat_bonus+1));
 			}
 
 			if( isset($prize) && $prize->get_type() == Prizes::TYPE_EXP ){
@@ -553,6 +558,44 @@ class Game extends Room {
 				$tot_exp_gain *= 2;
 				$tot_lux_gain *= 2;
 			}
+			
+			// tell the user about the hat/hh/campaign bonus(es)
+			if ($hat_bonus > 0 || isset($this->campaign) || HappyHour::isActive() == true) {
+				// hat bonus only
+				if ($hat_bonus > 0 && !isset($this->campaign) && HappyHour::isActive() != true) {
+					$player->write('award`Hat Bonus`exp X '.($hat_bonus+1));
+				}
+				
+				// campaign bonus only
+				else if ($hat_bonus == 0 && isset($this->campaign) && HappyHour::isActive() != true) {
+					$player->write('award`Campaign Bonus`exp X 2');
+				}
+				
+				// hh bonus only
+				else if ($hat_bonus == 0 && !isset($this->campaign) && HappyHour::isActive() == true) {
+					$player->write('award`Happy Hour Bonus`exp X 2');
+				}
+				
+				// hat + campaign bonuses
+				else if ($hat_bonus > 0 && isset($this->campaign) && HappyHour::isActive() != true) {
+					$player->write('award`Hat & Campaign Bonuses`exp X '.($hat_bonus+2));
+				}
+
+				// hat + hh bonuses
+				else if ($hat_bonus > 0 && !isset($this->campaign) && HappyHour::isActive() == true) {
+					$player->write('award`Hat & Happy Hour Bonuses`exp X '.($hat_bonus+2));
+				}
+				
+				// hh + campaign bonuses
+				else if ($hat_bonus == 0 && isset($this->campaign) && HappyHour::isActive() == true) {
+					$player->write('award`Hat & Happy Hour Bonuses`exp X 4');
+				}
+				
+				// hat+ campaign + hh bonuses
+				else if ($hat_bonus == 0 && isset($this->campaign) && HappyHour::isActive() == true) {
+					$player->write('award`Hat/Campaign/Happy Hour Bonuses`exp X '($hat_bonus+4));
+				}
+			}
 
 			//apply welcome back bonus after all multipliers
 			if( $welcome_back_bonus > 0 ) {
@@ -564,7 +607,7 @@ class Game extends Room {
 			if( $this->course_id == self::$artifact_level_id && $player->artifact == 0 && $player->wearing_hat(Hats::ARTIFACT) ) {
 				$player->artifact = 1;
 
-				$max_artifact_bonus = 11111;
+				$max_artifact_bonus = 15000;
 				$artifact_bonus = $max_artifact_bonus * $player->active_rank / 20;
 				if( $artifact_bonus > $max_artifact_bonus ) {
 					$artifact_bonus = $max_artifact_bonus;


### PR DESCRIPTION
This pull is a bunch of small updates that have combined to form one normal-sized pull.

HTTP Server Fixes/Additions:
 - A possible exploit where users could possibly log in as other users.  Fire-Bird was able to demonstrate something like this and I hope this fixes it (if it's not already fixed).
 - An error where accounts missing pr2 data would break update_account.php
 - An error where changing users' guild IDs in update_account.php would not increment the guild member count
 - A parenthesis error in the ban log that lets people make huge queries to the database.
 - An error that broke player_search.php
 - A small fix in search_by_email.php
 - HOPEFULLY fix F@H awards for good (the issue is that new folders aren't being made accounts in the fah database. I'm hoping that 53acfea will fix it, but PLEASE check my work to make sure).
 - Add `pr2_insert` into register_user.php to avoid broken accounts

Multiplayer Server Fixes/Additions:
 - Fix /kick (and add mod action logging for the kick function)
 - Fix /dc (and add mod action logging for the command)
 - Add test function `become_server_owner()` (right now just for Fred)
 - Add `rate_limit`, `name_to_id`, and `id_to_name` to fns/utils.php
 - Add rate limiting to recording play counts
 - Add EXP hat nerfing on Campaign (see issue #245)
 - Add player argument to admins' /debug command

Please check to make sure my port of the rate limiting function will work properly.  I'm not familiar with how the apcu functions work, so it very well could just not be compatible.