### PR TITLE
Botting patch, slight fixes

### DIFF
--- a/http_server/queries/get_info/pr2.php
+++ b/http_server/queries/get_info/pr2.php
@@ -1,0 +1,22 @@
+<?php
+
+function pr2_select_by_id($pdo, $id)
+{
+	$stmt = $pdo->prepare('SELECT * FROM pr2 WHERE user_id = :id');
+	$stmt->bindValue(':id', $id, PDO::PARAM_INT);
+	$stmt->execute();
+	
+	// get number of results
+	$row_count = $stmt->rowCount();
+	if ($row_count < 1) {
+		return false;
+	}
+	if ($row_count > 1) {
+		// log critical failure
+		return false;
+	}
+	
+	// return result
+	$result = $stmt->fetchAll(PDO::FETCH_OBJ);
+	return $result;
+}

--- a/http_server/queries/get_info/user.php
+++ b/http_server/queries/get_info/user.php
@@ -2,48 +2,42 @@
 
 function user_select_by_name($pdo, $name)
 {
-    $stmt = $pdo->prepare(
-        'SELECT 
-		user_id, name, email, register_ip, ip, time, register_time, power, status, read_message_id, guild 
-		FROM users WHERE name = :name'
-    );
-    $stmt->bindValue(':name', $name, PDO::PARAM_STR);
-    $stmt->execute();
-    
-    // get number of results
-    $row_count = $stmt->rowCount();
-    if ($row_count < 1) {
-        return false;
-    }
-    if ($row_count > 1) {
-        // critical failure
-    }
-    
-    // return result
-    $result = $stmt->fetchAll(PDO::FETCH_OBJ);
-    return $result;
+	$stmt = $pdo->prepare('SELECT user_id, name, email, register_ip, ip, time, register_time, power, status, read_message_id, guild FROM users WHERE name = :name');
+	$stmt->bindValue(':name', $name, PDO::PARAM_STR);
+	$stmt->execute();
+	
+	// get number of results
+	$row_count = $stmt->rowCount();
+	if ($row_count < 1) {
+		return false;
+	}
+	if ($row_count > 1) {
+		// log critical failure
+		return false;
+	}
+	
+	// return result
+	$result = $stmt->fetchAll(PDO::FETCH_OBJ);
+	return $result;
 }
 
 function user_select_by_id($pdo, $user_id)
 {
-    $stmt = $pdo->prepare(
-        'SELECT 
-		user_id, name, email, register_ip, ip, time, register_time, power, status, read_message_id, guild
-		FROM users WHERE user_id = :id'
-    );
-    $stmt->bindValue(':id', $user_id, PDO::PARAM_INT);
-    $stmt->execute();
-    
-    // get number of results
-    $row_count = $stmt->rowCount();
-    if ($row_count < 1) {
-        return false;
-    }
-    if ($row_count > 1) {
-        // critical failure
-    }
-    
-    // return result
-    $result = $stmt->fetchAll(PDO::FETCH_OBJ);
-    return $result;
+	$stmt = $pdo->prepare('SELECT user_id, name, email, register_ip, ip, time, register_time, power, status, read_message_id, guild FROM users WHERE user_id = :id');
+	$stmt->bindValue(':id', $user_id, PDO::PARAM_INT);
+	$stmt->execute();
+	
+	// get number of results
+	$row_count = $stmt->rowCount();
+	if ($row_count < 1) {
+		return false;
+	}
+	if ($row_count > 1) {
+		// log critical failure
+		return false;
+	}
+	
+	// return result
+	$result = $stmt->fetchAll(PDO::FETCH_OBJ);
+	return $result;
 }

--- a/http_server/queries/get_info/user.php
+++ b/http_server/queries/get_info/user.php
@@ -4,7 +4,7 @@ function user_select_by_name($pdo, $name)
 {
     $stmt = $pdo->prepare(
         'SELECT 
-		user_id, name, email, register_ip, ip, time, register_time, power, status, server_id, read_message_id, guild, register_date, active_date 
+		user_id, name, email, register_ip, ip, time, register_time, power, status, read_message_id, guild 
 		FROM users WHERE name = :name'
     );
     $stmt->bindValue(':name', $name, PDO::PARAM_STR);
@@ -28,7 +28,7 @@ function user_select_by_id($pdo, $user_id)
 {
     $stmt = $pdo->prepare(
         'SELECT 
-		user_id, name, email, register_ip, ip, time, register_time, power, status, server_id, read_message_id, guild, register_date, active_date 
+		user_id, name, email, register_ip, ip, time, register_time, power, status, read_message_id, guild
 		FROM users WHERE user_id = :id'
     );
     $stmt->bindValue(':id', $user_id, PDO::PARAM_INT);

--- a/http_server/www/mod/player_info.php
+++ b/http_server/www/mod/player_info.php
@@ -38,8 +38,8 @@ try {
     output_header('Player Info', true);
 
     //get dem infos
-    $user = user_select_by_id($user_id);
-    $pr2 = pr2_select_by_id($user_id);
+    $user = user_select_by_id($pdo, $user_id);
+    $pr2 = pr2_select_by_id($pdo, $user_id);
 
     // sanity check
     if ($user == false || $pr2 == false) {

--- a/http_server/www/mod/player_info.php
+++ b/http_server/www/mod/player_info.php
@@ -10,7 +10,7 @@ $mod_ip = get_ip();
 
 try {
     // sanity check
-    if (is_empty($user_id, false)) {
+    if (is_empty($user_id, false) && is_empty($force_ip) && is_empty($ip)) {
         throw new Exception("Invalid user ID specified.");
     }
     

--- a/multiplayer_server/HappyHour.php
+++ b/multiplayer_server/HappyHour.php
@@ -28,6 +28,14 @@ class HappyHour
             return $current_hour === self::$random_hour;
         }
     }
+    
+    public static function deactivate()
+    {
+        $time = time();
+        
+        if (self::$active_until > $time) {
+            self::$active_until = $time;
+        }
 }
 
 HappyHour::$random_hour = rand(0, 36);

--- a/multiplayer_server/HappyHour.php
+++ b/multiplayer_server/HappyHour.php
@@ -3,25 +3,25 @@
 class HappyHour
 {
 
-    private static $active_until = 0;
+    public static $hh_active_until = 0;
     public static $random_hour = 0;
 
     public static function activate($duration = 3600)
     {
         $time = time();
         
-        if (self::$active_until < $time) {
-            self::$active_until = $time;
+        if (self::$hh_active_until < $time) {
+            self::$hh_active_until = $time;
         }
         
-        self::$active_until += $duration;
+        self::$hh_active_until += $duration;
     }
 
     public static function isActive()
     {
         if (pr2_server::$tournament) {
             return false;
-        } elseif (self::$active_until >= time()) {
+        } elseif (self::$hh_active_until >= time()) {
             return true;
         } else {
             $current_hour = (int) date('G');
@@ -33,9 +33,19 @@ class HappyHour
     {
         $time = time();
         
-        if (self::$active_until > $time) {
-            self::$active_until = $time;
+        if (self::$hh_active_until > $time) {
+            self::$hh_active_until = 0;
         }
+    }
+    
+    public static function timeLeft()
+    {   
+        if (isActive() != false) {
+            return $hh_active_until;
+        } else {
+            return false;
+        }
+    }
 }
 
 HappyHour::$random_hour = rand(0, 36);

--- a/multiplayer_server/HappyHour.php
+++ b/multiplayer_server/HappyHour.php
@@ -40,8 +40,9 @@ class HappyHour
     
     public static function timeLeft()
     {   
-        if (isActive() != false) {
-            return $hh_active_until;
+        if (isActive() != false && $hh_active_until != 0) {
+            $timeleft = time() - $hh_active_until;
+            return $timeleft;
         } else {
             return false;
         }

--- a/multiplayer_server/Player.php
+++ b/multiplayer_server/Player.php
@@ -1207,6 +1207,7 @@ class Player
         $this->chat_ban = null;
         $this->domain = null;
         $this->temp_mod = null;
+        $this->server_owner = null;
         $this->status = null;
     }
 }

--- a/multiplayer_server/Player.php
+++ b/multiplayer_server/Player.php
@@ -448,8 +448,7 @@ class Player
                     $this->write("message`chat_message: $chat_message<br>port: $port<br>server_name: $server_name<br>server_id: $server_id<br>uptime: $uptime<br>private_server: $is_ps<br>server_guild: $guild_id<br>server_owner: $guild_owner<br>server_expire_time: $server_expire_time");
                 } elseif (strpos($chat_message, '/debug player ') === 0) {
                     $player_name = trim(substr($chat_message, 14));
-                    $player_id = name_to_id($db, $player_name);
-                    $player = id_to_player($player_id);
+                    $player = name_to_player($player_name);
                     
                     if (isset($player)) {
                         $pip = $player->ip;
@@ -498,7 +497,7 @@ class Player
                             ."ip: $pip<br>"
                             ."name: $pname | user_id: $puid<br>"
                             ."status: $pstatus<br>"
-                            ."group: $pgroup | temp_mod: $ptemp | server_owner $pso<br>"
+                            ."group: $pgroup | temp_mod: $ptemp | server_owner: $pso<br>"
                             ."guild_id: $pguild<br>"
                             ."active_rank: $parank | rank (no rt): $prank | rt_used: $prtused | rt_avail: $prtavail<br>"
                             ."exp_today: $pexp2day | exp_points: $pexppoints<br>"
@@ -549,8 +548,7 @@ class Player
                 if (strpos($chat_message, '/dc ') === 0) {
                     $dc_name = trim(substr($chat_message, 4)); // for /dc
                 }
-                $dc_id = name_to_id($db, $dc_name); // convert name to id
-                $dc_player = id_to_player($dc_id); // convert id to player
+                $dc_player = name_to_player($dc_name);
                 $safe_dc_name = htmlspecialchars($dc_player->name); // make the name safe to echo back to the user
                 
                 // permission checks
@@ -579,7 +577,6 @@ class Player
                 if ($chat_message == '/mod help') {
                     $this->write('systemChat`To promote someone to a server moderator, type "/mod promote" followed by their username. They will be a server moderator until they log out or are demoted. To demote an existing server moderator, type "/mod demote" followed by their username.');
                 } elseif (strpos($chat_message, '/mod promote ') === 0 || strpos($chat_message, '/mod demote ') === 0) {
-                    // get the user's name and ID
                     if (strpos($chat_message, '/mod promote ') === 0) {
                         $action = 'promote';
                         $to_name = trim(substr($chat_message, 13));
@@ -587,8 +584,7 @@ class Player
                         $action = 'demote';
                         $to_name = trim(substr($chat_message, 12));
                     }
-                    $to_id = name_to_id($db, $to_name);
-                    $target = id_to_player($to_id);
+                    $target = name_to_player($to_name);
                     $owner = $this;
                     
                     // do the appropriate action

--- a/multiplayer_server/Player.php
+++ b/multiplayer_server/Player.php
@@ -597,7 +597,7 @@ class Player
                     }
                     $this->write('systemChat`To find out if a Happy Hour is active and when it expires, type /hh status. '.$hhmsg_admin.$hhmsg_server_owner.$hhmsg_warning);
                 } elseif ($args[0] == 'activate' && $this->group >=3 && $this->server_owner == false) {
-                    if (HappyHour::isActive() != true) {
+                    if (HappyHour::isActive() != true && pr2_server::$tournament == false) {
                         if (!isset($args[1])) {
                             HappyHour::activate();
                         }
@@ -609,6 +609,8 @@ class Player
                             HappyHour::activate($args[1]);
                         }
                         $player_room->send_chat('systemChat`'.htmlspecialchars($this->name).' just triggered a Happy Hour!');
+                    } elseif (pr2_server::$tournament == true) {
+                        $this->write('systemChat`You can\'t activate a Happy Hour on a server with tournament mode enabled. Disable tournament mode and try again.');
                     } else {
                         $hh_timeleft = HappyHour::timeLeft();
                         $this->write('systemChat`There is already a Happy Hour on this server. It will expire in ' . format_duration($hh_timeleft) . '.');

--- a/multiplayer_server/Player.php
+++ b/multiplayer_server/Player.php
@@ -612,7 +612,7 @@ class Player
                             $mod = '<br>Moderator:<br>- /a (Announcement)<br>- /give *text*<br>- /kick *name*<br>- /disconnect *name*<br>- /clear';
                             $effects = '<br>Chat Effects:<br>- /b (Bold)<br>- /i (Italics)<br>- /u (Underlined)<br>- /li (Bulleted)';
                         }
-                        if ($this->group >= 3 && $guild_owner != $this->user_id && $guild_id != 183) {
+                        if ($this->group >= 3 && $this->server_owner == false) {
                             $admin = '<br>Admin:<br>- /promote *message*<br>- /restart_server<br>- /debug *arg*';
                         }
                         if ($this->server_owner == true) {

--- a/multiplayer_server/fns/data_fns.php
+++ b/multiplayer_server/fns/data_fns.php
@@ -114,24 +114,7 @@ function check_if_banned($connection, $user_id, $ip)
 
         //figure out what the best way to say this is
         $seconds = $expire_time - time();
-        if ($seconds < 60) {
-            $time_left = "$seconds second(s)";
-        } elseif ($seconds < 60*60) {
-            $minutes = round($seconds/60, 0);
-            $time_left = "$minutes minute(s)";
-        } elseif ($seconds < 60*60*24) {
-            $hours = round($seconds/60/60, 0);
-            $time_left = "$hours hour(s)";
-        } elseif ($seconds < 60*60*24*30) {
-            $days = round($seconds/60/60/24, 0);
-            $time_left = "$days day(s)";
-        } elseif ($seconds < 60*60*24*30*12) {
-            $months = round($seconds/60/60/24/30, 0);
-            $time_left = "$months month(s)";
-        } else {
-            $years = round($seconds/60/60/24/30/12, 0);
-            $time_left = "$years year(s)";
-        }
+        format_duration($seconds);
 
         //tell it to the world
         $output = "This account or ip address has been banned.\n"
@@ -141,6 +124,51 @@ function check_if_banned($connection, $user_id, $ip)
 
         throw new Exception($output);
     }
+}
+
+
+
+
+
+function format_duration($seconds)
+{
+    if ($seconds < 60) {
+        $time_left = "$seconds second";
+        if ($seconds != 1) {
+            $time_left .= 's';
+        }
+    } elseif ($seconds < 60*60) {
+        $minutes = round($seconds/60, 0);
+        $time_left = "$minutes minute";
+        if ($minutes != 1) {
+            $time_left .= 's';
+        }
+    } elseif ($seconds < 60*60*24) {
+        $hours = round($seconds/60/60, 0);
+        $time_left = "$hours hour";
+        if ($hours != 1) {
+            $time_left .= 's';
+        }
+    } elseif ($seconds < 60*60*24*30) {
+        $days = round($seconds/60/60/24, 0);
+        $time_left = "$days day";
+        if ($days != 1) {
+            $time_left .= 's';
+        }
+    } elseif ($seconds < 60*60*24*30*12) {
+        $months = round($seconds/60/60/24/30, 0);
+        $time_left = "$months month";
+        if ($months != 1) {
+            $time_left .= 's';
+        }
+    } else {
+        $years = round($seconds/60/60/24/30/12, 0);
+        $time_left = "$years year";
+        if ($years != 1) {
+            $time_left .= 's';
+        }
+    }
+    return $time_left;
 }
 
 

--- a/multiplayer_server/fns/utils.php
+++ b/multiplayer_server/fns/utils.php
@@ -58,7 +58,7 @@ function name_to_player($name)
     global $player_array;
     $return_player = null;
     foreach ($player_array as $player) {
-        if ($player->name == $name) {
+        if (strtolower($player->name) == strtolower($name)) {
             $return_player = $player;
             break;
         }

--- a/multiplayer_server/parts/Prizes.php
+++ b/multiplayer_server/parts/Prizes.php
@@ -11,7 +11,6 @@ class Prizes
     const TYPE_EPIC_HEAD = 'eHead';
     const TYPE_EPIC_BODY = 'eBody';
     const TYPE_EPIC_FEET = 'eFeet';
-    const TYPE_EXP = 'exp';
 
     private static $arr;
 
@@ -287,10 +286,6 @@ class Prizes
     public static $EPIC_BUNNY_FEET;
 
 
-    //---
-    public static $EXP_5;
-
-
     public static function init()
     {
 
@@ -564,10 +559,6 @@ class Prizes
         self::$EPIC_CROCODILE_FEET = new Prize(self::TYPE_EPIC_FEET, Feet::CROCODILE, 'Epic Upgrade!');
         self::$EPIC_VALENTINE_FEET = new Prize(self::TYPE_EPIC_FEET, Feet::VALENTINE, 'Epic Upgrade!');
         self::$EPIC_BUNNY_FEET = new Prize(self::TYPE_EPIC_FEET, Feet::BUNNY, 'Epic Upgrade!');
-
-
-        //---
-        self::$EXP_5 = new Prize(self::TYPE_EXP, 5, 'Exp');
     }
 
 

--- a/multiplayer_server/rooms/Game.php
+++ b/multiplayer_server/rooms/Game.php
@@ -510,18 +510,33 @@ class Game extends Room
             }
 
             //--- opponent bonus ---
-            for ($i = $place+1; $i < count($this->finish_array); $i++) {
-                $race_stats = $this->finish_array[$i];
-                $exp_gain = ($race_stats->rank+5) * $time_mod;
-                /*if($race_stats->ip == $player->ip) {
-                $exp_gain /= 2;
-                }*/
-                $exp_gain = ceil($this->apply_exp_curve($player, $exp_gain));
-                if (pr2_server::$no_prizes) {
-                    $exp_gain = 0;
+            // if/then with artifact check
+            if ($this->course_id != self::$artifact_level_id || $player->artifact == 1 || $player->wearing_hat(Hats::ARTIFACT) == false) {
+                for ($i = $place+1; $i < count($this->finish_array); $i++) {
+                    $race_stats = $this->finish_array[$i];
+                    $exp_gain = ($race_stats->rank+5) * $time_mod;
+                    /*if($race_stats->ip == $player->ip) {
+                    $exp_gain /= 2;
+                    }*/
+                    $exp_gain = ceil($this->apply_exp_curve($player, $exp_gain));
+                    if (pr2_server::$no_prizes) {
+                        $exp_gain = 0;
+                    }
+                    $tot_exp_gain += $exp_gain;
+                    $player->write('award`Defeated '.$race_stats->name.'`+ '.$exp_gain);
                 }
-                $tot_exp_gain += $exp_gain;
-                $player->write('award`Defeated '.$race_stats->name.'`+ '.$exp_gain);
+            }
+            else {
+                for ($i = $place+1; $i < count($this->finish_array); $i++) {
+                    $race_stats = $this->finish_array[$i];
+                    $exp_gain = ($race_stats->rank+5) * $time_mod;
+                    $exp_gain = ceil($this->apply_exp_curve($player, $exp_gain));
+                    if (pr2_server::$no_prizes) {
+                        $exp_gain = 0;
+                    }
+                    $tot_exp_gain += $exp_gain;
+                }
+                $player->write('award`Defeated Opponents`+ '.$exp_gain);
             }
 
             // hat, campaign, hh bonuses

--- a/multiplayer_server/rooms/Game.php
+++ b/multiplayer_server/rooms/Game.php
@@ -463,10 +463,9 @@ class Game extends Room
             if (isset($prize)) {
                 $autoset = ( $prize->get_type() == 'hat' );
                 $result = $player->gain_part($prize->get_type(), $prize->get_id(), $autoset);
-                if (!$result) {
-                    $prize = Prizes::$EXP_5;
+                if ($result != false) {
+                    $player->write('winPrize`' . $prize->to_str());
                 }
-                $player->write('winPrize`' . $prize->to_str());
             }
 
 


### PR DESCRIPTION
HTTP Server:
 - Fixed query in queries/get_info/user.php
 - Created query for pr2_select (check the code, commit 3e97cd5)
 - Fixed player_info.php and semi-updated it to PDO
 - Fixed server crash on admin server owner logout
 - Fixed leaderboard.php

Socket Server:
 - Made `name_to_player()` case insensitive and removed `name_to_id()` calls
 - Fixed/optimized moderation.php, promote_to_moderator.php
 - Disabled and removed +5 EXP bonus
 - Added /hh command (see comments on 93c168a for more details) 
 - Added a check for if the user is winning the artifact (see comments on 927f7f9). Hopefully it works?

There have been reports of botting on levels with a set prize with the +5 EXP bonus, and it's confirmed by those levels' play counts (see The Golden Compass and Hat Factory as examples).  Basically, they enter a level and auto-win as soon as the race starts, collecting the +5 EXP.  Do this a bunch of times and you get an exorbitant amount of EXP.

The easy solution here is to remove the +5 EXP bonus because:
 - The bonus popup doesn't show up in the client anymore
 - It has no effect since EXP has been inflated over the years
 - It would be a lot easier than trying to patch the auto-win glitch, which may require a client edit

If we can patch the auto-win glitch, I wouldn't be opposed to putting the bonus back in the future; However, right now this is a quick fix to stop botting.