### PR TITLE
Add part array validation on logout, fix warnings

### DIFF
--- a/http_server/www/admin/update_account.php
+++ b/http_server/www/admin/update_account.php
@@ -97,6 +97,11 @@ function update($db)
     $user_id = (int) find('id');
     $email = find('email');
     $account_changes = find('account_changes');
+    $hats = find('hats');
+    $heads = find('heads');
+    $bodies = find('bodies');
+    $feet = find('feet');
+    
 
     // call user information
     $user = $db->grab_row('user_select', array($user_id));
@@ -119,6 +124,20 @@ function update($db)
         $change_id = $db->grab('change_id', 'changing_email_select', array($code));
         $db->call('changing_email_complete', array($change_id, ''));
     }
+    
+    // make sure none of the part values are blank to avoid server crashes
+    if (is_empty($hats, false) {
+        $hats = "1";
+    }
+    if (is_empty($heads, false) {
+        $heads = "1";
+    }
+    if (is_empty($bodies, false) {
+        $bodies = "1";
+    }
+    if (is_empty($feet, false) {
+        $feet = "1";
+    }
 
     // check for description of changes
     if (is_empty($account_changes)) {
@@ -133,10 +152,10 @@ function update($db)
         find('name'),
         find('email'),
         $guild_id,
-        find('hats'),
-        find('heads'),
-        find('bodies'),
-        find('feet'),
+        $hats,
+        $heads,
+        $bodies,
+        $feet,
         find('eHats'),
         find('eHeads'),
         find('eBodies'),

--- a/http_server/www/admin/update_account.php
+++ b/http_server/www/admin/update_account.php
@@ -126,16 +126,16 @@ function update($db)
     }
     
     // make sure none of the part values are blank to avoid server crashes
-    if (is_empty($hats, false) {
+    if (is_empty($hats, false)) {
         $hats = "1";
     }
-    if (is_empty($heads, false) {
+    if (is_empty($heads, false)) {
         $heads = "1";
     }
-    if (is_empty($bodies, false) {
+    if (is_empty($bodies, false)) {
         $bodies = "1";
     }
-    if (is_empty($feet, false) {
+    if (is_empty($feet, false)) {
         $feet = "1";
     }
 

--- a/http_server/www/leaderboard.php
+++ b/http_server/www/leaderboard.php
@@ -36,7 +36,7 @@ try {
     $users_result = $db->query(
         "SELECT
 						users.name as name,
-						users.power as group,
+						users.power as power,
 						(rank_tokens.used_tokens + pr2.rank) AS active_rank,
 						pr2.hat_array AS hats
 					FROM users, pr2, rank_tokens
@@ -72,7 +72,7 @@ try {
         $safe_name = str_replace(" ", "&nbsp;", $safe_name);
 
         // group
-        $group = (int) $user->group;
+        $group = (int) $user->power;
         $group_color = $group_colors[$group];
 
         // rank

--- a/multiplayer_server/Player.php
+++ b/multiplayer_server/Player.php
@@ -1075,9 +1075,21 @@ class Player
 
     public function save_info()
     {
-        global $port;
-        global $server_id;
-        global $db;
+        global $port, $server_id, $db;
+        
+        // make sure none of the part values are blank to avoid server crashes
+        if (is_empty($this->hat, false) {
+            $this->gain_part('hat', 1, true);
+        }
+        if (is_empty($this->head, false) {
+            $this->gain_part('head', 1, true);
+        }
+        if (is_empty($this->body, false) {
+            $this->gain_part('body', 1, true);
+        }
+        if (is_empty($this->feet, false) {
+            $this->gain_part('feet', 1, true);
+        }
 
         // auto removing some hat?
         $index = array_search(27, $this->hat_array);

--- a/multiplayer_server/Player.php
+++ b/multiplayer_server/Player.php
@@ -1078,16 +1078,16 @@ class Player
         global $port, $server_id, $db;
         
         // make sure none of the part values are blank to avoid server crashes
-        if (is_empty($this->hat, false) {
+        if (is_empty($this->hat, false)) {
             $this->gain_part('hat', 1, true);
         }
-        if (is_empty($this->head, false) {
+        if (is_empty($this->head, false)) {
             $this->gain_part('head', 1, true);
         }
-        if (is_empty($this->body, false) {
+        if (is_empty($this->body, false)) {
             $this->gain_part('body', 1, true);
         }
-        if (is_empty($this->feet, false) {
+        if (is_empty($this->feet, false)) {
             $this->gain_part('feet', 1, true);
         }
 

--- a/multiplayer_server/Player.php
+++ b/multiplayer_server/Player.php
@@ -594,7 +594,7 @@ class Player
                     } elseif ($this->group >= 3 && $this->server_owner == true) {
                         $hhmsg_server_owner = "To deactivate the current Happy Hour, type /hh deactivate. $hhmsg_warning";
                     }
-                    $this->write('systemChat`To find out if a Happy Hour is active and when it expires, type /hh status. '.$hhmsg_admin.$hhmsg_server_owner.$hhmsg_warning);
+                    $this->write('systemChat`To find out if a Happy Hour is active and when it expires, type /hh status. '.$hhmsg_admin.$hhmsg_server_owner);
                 } elseif ($args[0] == 'activate' && $this->group >=3 && $this->server_owner == false) {
                     if (HappyHour::isActive() != true && pr2_server::$tournament == false) {
                         if (!isset($args[1])) {

--- a/multiplayer_server/client/moderation.php
+++ b/multiplayer_server/client/moderation.php
@@ -85,9 +85,12 @@ function client_warn($socket, $data)
                 $time = 60;
                 break;
             default:
-                $player->write('message`Error: Invalid warning number.');
+                $mod->write('message`Error: Invalid warning number.');
                 break;
         }
+        
+        // warn the user
+        $warned->chat_ban = time() + $time;
 
         if (isset($mod->chat_room)) {
             $mod->chat_room->send_chat("systemChat`$safe_mname has given $safe_wname $num $w_str. They have been banned from the chat for $time seconds.");

--- a/multiplayer_server/fns/data_fns.php
+++ b/multiplayer_server/fns/data_fns.php
@@ -28,6 +28,39 @@ function find_variable($string, $default)
 
 
 
+//--- tests if a value is empty using a variety of functions --------------------------------
+function is_empty($str, $incl_zero = true)
+{
+    /*
+    $incl_zero: checks if the user wants to include the string "0" in the empty check.
+    If not, empty($str) will make this function return true.
+    */
+    
+    // if the string length is 0, it's empty
+    if (strlen(trim($str)) === 0) {
+        return true;
+    }
+    // if the string isn't set, it's empty
+    if (!isset($str)) {
+        return true;
+    }
+    // if the string is empty and not 0, it's empty
+    if ($incl_zero) {
+        if (empty($str) && $str != '0') {
+            return true;
+        }
+    } // if the string is empty, it's empty
+    else {
+        if (empty($str)) {
+            return true;
+        }
+    }
+    // you're still here? must mean $str isn't empty
+    return false;
+}
+
+
+
 //--- tests to see if a string contains obscene words ---------------------------------------
 function is_obscene($str)
 {


### PR DESCRIPTION
Avoid future problems with empty part arrays by making sure each array has something in it before attempting to log out (`save_info()` in player.php or saving player data in update_account.php).  It's good to have validation for the part arrays just in case this happens again somewhere down the line.

Please make sure adding the check to `save_info()` will be better than adding it to `verify_parts()`.

Also included in this pull:
 - Add /hh status to the members' /help command.
 - Fix warnings (for some reason past me thought it would be a good idea to remove the code that actually administers a chat ban)