### PR TITLE
Fixing Player Overflow

### DIFF
--- a/multiplayer_server/rooms/LevelListRoom.php
+++ b/multiplayer_server/rooms/LevelListRoom.php
@@ -34,7 +34,7 @@ class LevelListRoom extends Room
     
     public function fill_slot($player, $course_id, $slot)
     {
-        if (!is_numeric($slot) || $slot < 0 || $slot > 3) {
+        if ((!is_numeric($slot) || ($slot < 0 && $slot > 3)) {
             $slot = 0;
         }
         if (isset($this->course_array[$course_id])) {


### PR DESCRIPTION
This is a fix that prevents slots from being refilled. Refilling slots can cause a player overflow in races. The only time a slot should be refilled is when it doesn't have a numerical value.