### PR TITLE
Continue the PDOcalypse, fix a few things

### DIFF
--- a/http_server/queries/changing_emails/changing_email_insert.php
+++ b/http_server/queries/changing_emails/changing_email_insert.php
@@ -4,23 +4,23 @@ function changing_email_insert($pdo, $user_id, $old_email, $new_email, $code, $i
 {
     $stmt = $pdo->prepare('
         INSERT INTO changing_emails
-        SET user_id = :user_id,
-            old_email = :old_email,
-            new_email = :new_email,
-            code = :code,
-            request_ip = :ip,
-            status = "pending",
-            date = NOW()
+                SET user_id = :user_id,
+                    old_email = :old_email,
+                    new_email = :new_email,
+                    code = :code,
+                    request_ip = :ip,
+                    status = "pending",
+                    date = NOW()
     ');
     $stmt->bindValue(':user_id', $user_id, PDO::PARAM_INT);
     $stmt->bindValue(':old_email', $old_email, PDO::PARAM_STR);
     $stmt->bindValue(':new_email', $new_email, PDO::PARAM_STR);
     $stmt->bindValue(':code', $code, PDO::PARAM_STR);
     $stmt->bindValue(':ip', $ip, PDO::PARAM_STR);
-
     $result = $stmt->execute();
+
     if ($result === false) {
-        throw new Exception('Could not start email change');
+        throw new Exception('Could not start email change.');
     }
 
     return $result;

--- a/http_server/queries/changing_emails/changing_emails_select_by_user.php
+++ b/http_server/queries/changing_emails/changing_emails_select_by_user.php
@@ -3,9 +3,10 @@
 function changing_emails_select_by_user($pdo, $user_id, $suppress_error = false)
 {
     $stmt = $pdo->prepare('
-        SELECT change_id, old_email, new_email, code, date, request_ip, confirm_ip, status
-          FROM changing_emails
-         WHERE user_id = :user_id
+          SELECT change_id, old_email, new_email, code, date, request_ip, confirm_ip, status
+            FROM changing_emails
+           WHERE user_id = :user_id
+        ORDER BY change_id ASC
     ');
     $stmt->bindValue(':user_id', $user_id, PDO::PARAM_INT);
 

--- a/http_server/queries/guild_transfers/guild_transfers_select_by_guild.php
+++ b/http_server/queries/guild_transfers/guild_transfers_select_by_guild.php
@@ -3,9 +3,10 @@
 function guild_transfers_select_by_guild($pdo, $guild_id, $suppress_error = false)
 {
     $stmt = $pdo->prepare('
-        SELECT transfer_id, old_owner_id, new_owner_id, code, date, request_ip, confirm_ip, status
-          FROM guild_transfers
-         WHERE guild_id = :guild_id
+          SELECT transfer_id, old_owner_id, new_owner_id, code, date, request_ip, confirm_ip, status
+            FROM guild_transfers
+           WHERE guild_id = :guild_id
+        ORDER BY transfer_id ASC
     ');
     $stmt->bindValue(':guild_id', $guild_id, PDO::PARAM_INT);
     $result = $stmt->execute();

--- a/http_server/queries/levels/levels_search.php
+++ b/http_server/queries/levels/levels_search.php
@@ -1,53 +1,34 @@
 <?php
 
-function levels_search ($pdo, $search, $in_mode = 'title', $in_start = 0, $in_count = 9, $in_order_by = 'date', $in_dir = 'desc')
+function levels_search ($pdo, $search, $in_mode = 'title', $in_start = 0, $in_count = 9, $in_order = 'date', $in_dir = 'desc')
 {
     $start = min( max( (int)$in_start, 0), 100 );
     $count = min( max( (int)$in_count, 0), 100 );
 
-    switch($in_order_by)
-    {
-        case 'rating':
-            $order_by = 'pr2_levels.rating';
-            break;
-        case 'date':
-            $order_by = 'pr2_levels.time';
-            break;
-        case 'alphabetical':
-            $order_by = 'pr2_levels.title';
-            break;
-        case 'popularity':
-            $order_by = 'pr2_levels.play_count';
-            break;
-        default:
-            $order_by = 'pr2_levels.time';
-            break;
+    // order by
+    $order_by = 'pr2_levels.';
+    if ($in_order == 'rating') {
+        $order_by .= 'rating';
+    } else if ($in_order == 'alphabetical') {
+        $order_by .= 'title';
+    } else if ($in_order == 'popularity') {
+        $order_by .= 'play_count';
+    } else {
+        $order_by .= 'time';
     }
 
-    switch ($in_dir)
-    {
-        case 'asc':
-            $dir = 'ASC';
-            break;
-        case 'desc':
-            $dir = 'DESC';
-            break;
-        default:
-            $dir = 'DESC';
-            break;
+    // direction
+    if ($in_dir == 'asc') {
+        $dir = 'ASC';
+    } else {
+        $dir = 'DESC';
     }
 
-    switch ($in_mode)
-    {
-        case 'title':
-            $where = 'users.name = :search';
-            break;
-        case 'user':
-            $where = 'users.name = :search';
-            break;
-        default:
-            $where = 'MATCH (title) AGAINST (:search IN BOOLEAN MODE)';
-            break;
+    // search mode
+    if ($in_mode == 'title') {
+        $where = 'MATCH (title) AGAINST (:search IN BOOLEAN MODE)';
+    } else {
+        $where = 'users.name = :search';
     }
 
     $stmt = $pdo->prepare("

--- a/http_server/queries/recent_logins/recent_logins_select.php
+++ b/http_server/queries/recent_logins/recent_logins_select.php
@@ -1,6 +1,6 @@
 <?php
 
-function recent_logins_select($pdo, $user_id, $count = 100, $suppress_error = false)
+function recent_logins_select($pdo, $user_id, $suppress_error = false, $count = 100)
 {
     $count = (int) $count;
     $stmt = $pdo->prepare('

--- a/http_server/queries/staff/actions/mod_action_insert.php
+++ b/http_server/queries/staff/actions/mod_action_insert.php
@@ -1,0 +1,24 @@
+<?php
+
+function mod_action_insert($pdo, $mod_id, $message, $extra, $ip)
+{
+    $stmt = $pdo->prepare('
+        INSERT INTO mod_actions
+        SET time = NOW(),
+            mod_id = :mod_id,
+            message = :message,
+            extra = :extra,
+            ip = :ip
+    ');
+    $stmt->bindValue(':mod_id', $mod_id, PDO::PARAM_INT);
+    $stmt->bindValue(':message', $message, PDO::PARAM_STR);
+    $stmt->bindValue(':extra', $extra, PDO::PARAM_STR);
+    $stmt->bindValue(':ip', $ip, PDO::PARAM_STR);
+    $result = $stmt->execute();
+    
+    if ($result === false) {
+        throw new Exception('Could not record moderator action.');
+    }
+
+    return $result;
+}

--- a/http_server/queries/staff/ban_user.php
+++ b/http_server/queries/staff/ban_user.php
@@ -2,13 +2,22 @@
 
 function throttle_bans($pdo, $mod_user_id)
 {
-    $time = (int) (time() - 3600);
+    $throttle_time = (int) (time() - 3600);
   
-    $stmt = $pdo->prepare('SELECT COUNT(*) as recent_ban_count FROM bans WHERE mod_user_id = :mod AND time > UNIX_TIMESTAMP(NOW() - INTERVAL 1 HOUR)');
+    $stmt = $pdo->prepare("
+        SELECT COUNT(*) as recent_ban_count
+	  FROM bans
+	 WHERE mod_user_id = :mod
+	   AND time > $throttle_time
+    ");
     $stmt->bindValue(':mod', $mod_user_id, PDO::PARAM_INT);
-    $stmt->execute();
-    $row = $stmt->fetchAll(PDO::FETCH_OBJ);
-    return $row;
+    $result = $stmt->execute();
+    
+    if ($result === false) {
+    	throw new Exception("Could not query ban throttle.");
+    }
+
+    return $stmt->fetchAll(PDO::FETCH_OBJ);
 }
 
 function ban_user($pdo, $banned_ip, $banned_user_id, $mod_user_id, $expire_time, $reason, $record, $banned_name, $mod_name, $ip_ban, $account_ban)

--- a/http_server/queries/staff/bans/ban_user.php
+++ b/http_server/queries/staff/bans/ban_user.php
@@ -1,25 +1,5 @@
 <?php
 
-function throttle_bans($pdo, $mod_user_id)
-{
-    $throttle_time = (int) (time() - 3600);
-  
-    $stmt = $pdo->prepare("
-        SELECT COUNT(*) as recent_ban_count
-	  FROM bans
-	 WHERE mod_user_id = :mod
-	   AND time > $throttle_time
-    ");
-    $stmt->bindValue(':mod', $mod_user_id, PDO::PARAM_INT);
-    $result = $stmt->execute();
-    
-    if ($result === false) {
-    	throw new Exception("Could not query ban throttle.");
-    }
-
-    return $stmt->fetchAll(PDO::FETCH_OBJ);
-}
-
 function ban_user($pdo, $banned_ip, $banned_user_id, $mod_user_id, $expire_time, $reason, $record, $banned_name, $mod_name, $ip_ban, $account_ban)
 {
     $stmt = $pdo->prepare('

--- a/http_server/queries/staff/bans/throttle_bans.php
+++ b/http_server/queries/staff/bans/throttle_bans.php
@@ -1,0 +1,21 @@
+<?php
+
+function throttle_bans($pdo, $mod_user_id)
+{
+    $throttle_time = (int) (time() - 3600);
+  
+    $stmt = $pdo->prepare("
+        SELECT COUNT(*) as recent_ban_count
+	  FROM bans
+	 WHERE mod_user_id = :mod
+	   AND time > $throttle_time
+    ");
+    $stmt->bindValue(':mod', $mod_user_id, PDO::PARAM_INT);
+    $result = $stmt->execute();
+    
+    if ($result === false) {
+    	throw new Exception("Could not query ban throttle.");
+    }
+
+    return $stmt->fetchAll(PDO::FETCH_OBJ);
+}

--- a/http_server/queries/staff/level_unpublish.php
+++ b/http_server/queries/staff/level_unpublish.php
@@ -1,12 +1,23 @@
 <?php
 
-function level_unpublish($pdo, $level_id)
+function level_unpublish($pdo, $level_id, $suppress_error = false)
 {
-    $stmt = $pdo->prepare('UPDATE pr2_levels SET live = 0, pass = NULL WHERE level_id = ?');
-    $stmt->bindValue(1, $level_ID, PDO::PARAM_INT);
+    $stmt = $pdo->prepare('
+        UPDATE pr2_levels
+           SET live = 0,
+               pass = NULL
+         WHERE level_id = :level_id
+    ');
+    $stmt->bindValue(':level_id', $level_id, PDO::PARAM_INT);
     $result = $stmt->execute();
+    
     if ($result === false) {
-        throw new Exception("Could not unpublish level.");
+        if ($suppress_error === false) {
+            throw new Exception("Could not unpublish level.");
+        }
+        else {
+            return false;
+        }
     }
     return $result;
 }

--- a/http_server/queries/users/user_select_expanded.php
+++ b/http_server/queries/users/user_select_expanded.php
@@ -32,7 +32,7 @@ function user_select_expanded ($pdo, $user_id)
 
     $user = $stmt->fetch(PDO::FETCH_OBJ);
     if ($user === false) {
-        throw new Exception('Could not find a user with that ID.');
+        throw new Exception('Could not find a user with that name or ID.');
     }
 
     return $user;

--- a/http_server/queries/users/user_select_expanded.php
+++ b/http_server/queries/users/user_select_expanded.php
@@ -20,14 +20,14 @@ function user_select_expanded ($pdo, $user_id)
         LEFT JOIN pr2 ON users.user_id = pr2.user_id
         LEFT JOIN rank_tokens ON rank_tokens.user_id = pr2.user_id
         LEFT JOIN epic_upgrades ON users.user_id = epic_upgrades.user_id
-        WHERE users.user_id = p_user_id
+        WHERE users.user_id = :user_id
         LIMIT 1
     ');
     $stmt->bindValue(':user_id', $user_id, PDO::PARAM_INT);
 
     $result = $stmt->execute();
     if ($result === false) {
-        throw new Exception('Could not select expanded pr2 user');
+        throw new Exception('Could not execute pdo function user_select_expanded.');
     }
 
     $user = $stmt->fetch(PDO::FETCH_OBJ);

--- a/http_server/www/account_confirm_email_change.php
+++ b/http_server/www/account_confirm_email_change.php
@@ -6,7 +6,6 @@ require_once __DIR__ . '/../queries/changing_emails/changing_email_select.php';
 require_once __DIR__ . '/../queries/changing_emails/changing_email_complete.php';
 require_once __DIR__ . '/../queries/users/user_update_email.php';
 
-
 $code = $_GET['code'];
 $ip = get_ip();
 
@@ -34,10 +33,14 @@ try {
     // push the change through
     changing_email_complete($pdo, $change_id, $ip);
     user_update_email($pdo, $user_id, $old_email, $new_email);
+    
+    // make some variables
+    $safe_old_email = htmlspecialchars($old_email);
+    $safe_new_email = htmlspecialchars($new_email);
 
     // tell it to the world
     output_header('Confirm Email Change');
-    echo "Great success! Your email address has been changed from {htmlspecialchars($old_email)} to {htmlspecialchars($new_email)}.";
+    echo "Great success! Your email address has been changed from $safe_old_email to $safe_new_email.";
     output_footer();
 } catch (Exception $e) {
     output_header('Confirm Email Change');

--- a/http_server/www/admin/guild_deep_info.php
+++ b/http_server/www/admin/guild_deep_info.php
@@ -61,6 +61,9 @@ function output_object($obj, $sep = '<br/>')
 {
     if ($obj !== false) {
         foreach ($obj as $var => $val) {
+            if ($var == 'name') {
+                $val = "<a href='player_deep_info.php?name1=$val'>$val</a>";
+            }
             if ($var != 'guild_id') {
                 echo "$var: ".htmlspecialchars($val)."$sep";
             }

--- a/http_server/www/admin/player_deep_info.php
+++ b/http_server/www/admin/player_deep_info.php
@@ -47,7 +47,7 @@ try {
                 output_object($epic);
                 output_objects($changing_emails);
                 output_objects($logins);
-                echo '<a href="update_account.php?id='.$user->user_id.'">edit</a><br><br><br>';
+                echo '<a href="update_account.php?id='.$user->user_id.'">edit</a> | <a href="//pr2hub.com/mod/ban.php?user_id='.$user->user_id.'&force_ip=">ban</a><br><br><br>';
             } catch (Exception $e) {
                 echo "<i>Error: ".$e->getMessage()."</i><br><br>";
             }

--- a/http_server/www/admin/player_deep_info.php
+++ b/http_server/www/admin/player_deep_info.php
@@ -77,6 +77,9 @@ function output_object($obj, $sep = '<br/>')
 {
     if ($obj !== false) {
         foreach ($obj as $var => $val) {
+            if ($var == 'guild') {
+                $val = "<a href='guild_deep_info.php?guild_id=$val'>$val</a>";
+            }
             if ($var == 'time' || $var == 'register_time') {
                 $val = date('M j, Y g:i A', $val);
             }

--- a/http_server/www/admin/search_by_email.php
+++ b/http_server/www/admin/search_by_email.php
@@ -54,12 +54,13 @@ try {
     output_search($disp_email);
 
     // output the number of results
-    if (count($users) === 1) {
+    $count = count($users);
+    if ($count == 1) {
         $res = 'result';
     } else {
         $res = 'results';
     }
-    echo "{count($users)} $res found for the email address \"$disp_email\".<br><br>";
+    echo "$count $res found for the email address \"$disp_email\".<br><br>";
 
     // only gonna get here if there were results
     foreach ($users as $row) {

--- a/http_server/www/admin/update_account.php
+++ b/http_server/www/admin/update_account.php
@@ -11,6 +11,7 @@ require_once __DIR__ . '/../../queries/epic_upgrades/epic_upgrades_select.php'; 
 require_once __DIR__ . '/../../queries/staff/admin/admin_account_update.php'; // pdo
 
 // guild, email functions
+require_once __DIR__ . '/../../queries/guilds/guild_select.php'; // pdo
 require_once __DIR__ . '/../../queries/guilds/guild_increment_member.php'; // pdo
 require_once __DIR__ . '/../../queries/changing_emails/changing_email_insert.php'; // pdo
 require_once __DIR__ . '/../../queries/changing_emails/changing_email_select.php'; // pdo
@@ -166,14 +167,15 @@ function update($pdo, $admin)
 
     // adjust guild member count
     if ($user->guild != $guild_id) {
+        guild_select($pdo, $guild_id); // make sure the new guild exists
         if ($user->guild != 0) {
-            $result = guild_increment_member($pdo, $user->guild, -1);
+            $result = guild_increment_member($pdo, $user->guild, -1, true);
             if ($result === false) {
                 throw new Exception("Could not increment guild member count in guild $user->guild.");
             }
         }
         if ($guild_id != 0) {
-            $result = guild_increment_member($pdo, $user->guild, 1);
+            $result = guild_increment_member($pdo, $user->guild, 1, true);
             if ($result === false) {
                 throw new Exception("Could not increment guild member count in guild $guild_id.");
             }

--- a/http_server/www/admin/update_account.php
+++ b/http_server/www/admin/update_account.php
@@ -160,7 +160,7 @@ function update($pdo, $admin)
     }
 
     // if there's nothing to change, no need to query the database any further
-    if ($update_user === true && $update_pr2 === true && $update_epic === true) {
+    if ($update_user === false && $update_pr2 === false && $update_epic === false) {
         throw new Exception('No changes to be made.');
     }
 

--- a/http_server/www/ban_user.php
+++ b/http_server/www/ban_user.php
@@ -2,12 +2,17 @@
 
 header("Content-type: text/plain");
 
+// misc functions
 require_once __DIR__ . '/../fns/all_fns.php';
-require_once __DIR__ . '/../queries/users/user_select_by_name.php'; // pdo
-require_once __DIR__ . '/../queries/staff/action_log.php'; // pdo
-require_once __DIR__ . '/../queries/staff/ban_user.php'; // pdo
-require_once __DIR__ . '/../queries/tokens/tokens_delete_by_user.php';
 
+// pdo queries
+require_once __DIR__ . '/../queries/users/user_select_by_name.php'; // select user by name
+require_once __DIR__ . '/../queries/staff/actions/mod_action_insert.php'; // insert into mod action log
+require_once __DIR__ . '/../queries/staff/bans/throttle_bans.php'; // throttle mod bans per hour
+require_once __DIR__ . '/../queries/staff/bans/ban_user.php'; // ban user
+require_once __DIR__ . '/../queries/tokens/tokens_delete_by_user.php'; // delete user token
+
+// variables
 $banned_name = default_val($_POST['banned_name']);
 $duration = (int) default_val($_POST['duration'], 60);
 $reason = default_val($_POST['reason'], '');
@@ -16,7 +21,6 @@ $using_mod_site = default_val($_POST['using_mod_site'], 'no');
 $redirect = default_val($_POST['redirect'], 'no');
 $type = default_val($_POST['type'], 'both');
 $force_ip = default_val($_POST['force_ip']);
-
 $ip = get_ip();
 
 // if it's a month/year ban coming from PR2, correct the weird ban times
@@ -149,7 +153,7 @@ try {
     $action_string = "$mod_user_name banned $banned_name from $ip {duration: $disp_duration, account_ban: $is_account_ban, ip_ban: $is_ip_ban, expire_time: $disp_expire_time, $disp_reason}";
 
     //record the ban in the action log
-    log_mod_action($pdo, $action_string, $mod_user_id, $ip);
+    mod_action_insert($pdo, $mod_user_id, $action_string, 'ban', $ip);
 
     if ($using_mod_site == 'yes' && $redirect == 'yes') {
         header('Location: //pr2hub.com/mod/player_info.php?user_id='.$banned_user_id.'&force_ip='.$force_ip);

--- a/http_server/www/mod/player_info.php
+++ b/http_server/www/mod/player_info.php
@@ -9,6 +9,7 @@ require_once __DIR__ . '/../../queries/bans/bans_select_by_ip.php';
 
 $user_id = (int) default_val($_GET['user_id'], 0);
 $force_ip = find_no_cookie('force_ip');
+$ip = find_no_cookie('ip');
 
 $mod_ip = get_ip();
 
@@ -40,7 +41,7 @@ try {
 
     //get dem infos
     $user = user_select($pdo, $user_id);
-    $pr2 = pr2_select($pdo, $user_id);
+    $pr2 = pr2_select($pdo, $user_id, true);
 
     // sanity check
     if ($user == false || $pr2 == false) {

--- a/http_server/www/player_search.php
+++ b/http_server/www/player_search.php
@@ -103,7 +103,7 @@ function output_page($db, $user)
         $guild = $db->grab_row('guild_select', array($guild_id));
         $guild_name = $guild->guild_name;
     } else {
-        $guild_name = '';
+        $guild_name = '<i>none</i>';
     }
 
     // group html change if staff


### PR DESCRIPTION
Fixes:
 - No change validation -> update_account.php
 - Check for a non-existent guild when changing user into a new guild -> update_account.php
 - Fix IP history -> player_deep_info.php
 - Fix user_select_expanded
 - Fix bans
 - Fix level unpublishing (check my commit comments on cf8a7e7)
 - Fix level searches (they were only searching by user)
 - Revert curly braces
 - Rearrange some functions and calls
 - Fix random things broken in mod/player_info.php
 - Display "none" on no guild in player search

Nice things:
 - Admins now have some friendly links on guild_deep_info and player_deep_info

It sounds like a lot, but most of it was small changes in a few files.  One thing to note going forward: curly braces don't work the way you used them in 851c7bc, dadd592, and 7de6073.

Lastly, for the life of me, I cannot figure out why the heck `changing_email_insert` isn't working as it should.  I'm assuming the table `changing_emails` is a copy of the table `guild_transfers`, so it's seriously stumping me as to why it's not working.  See 891d99d for more information.