### PR TITLE
Fix assorted (many) errors

### DIFF
--- a/http_server/queries/campaign/campaign_select_by_id.php
+++ b/http_server/queries/campaign/campaign_select_by_id.php
@@ -9,11 +9,11 @@ function campaign_select_by_id ($pdo, $campaign_id)
         ORDER BY level_num
     ');
     $stmt->bindValue(':campaign_id', $campaign_id, PDO::PARAM_INT);
-
     $result = $stmt->execute();
+    
     if ($result === false) {
-        throw new Exception('Could not select campaign.');
+        throw new Exception('Could not perform query campaign_select_by_id.');
     }
 
-    return $stmt->fetchAll();
+    return $stmt->fetchAll(PDO::FETCH_OBJ);
 }

--- a/http_server/queries/guild_transfers/guild_transfer_complete.php
+++ b/http_server/queries/guild_transfers/guild_transfer_complete.php
@@ -8,7 +8,7 @@ function guild_transfer_complete($pdo, $transfer_id, $ip)
                confirm_ip = :ip
          WHERE transfer_id = :transfer_id
     ');
-    $stmt->bindValue(':transfer_id', $change_id, PDO::PARAM_INT);
+    $stmt->bindValue(':transfer_id', $transfer_id, PDO::PARAM_INT);
     $stmt->bindValue(':ip', $ip, PDO::PARAM_STR);
     $result = $stmt->execute();
     

--- a/http_server/queries/guilds/guild_increment_gp.php
+++ b/http_server/queries/guilds/guild_increment_gp.php
@@ -4,9 +4,9 @@ function guild_increment_gp($pdo, $guild_id, $gp)
 {
     $stmt = $pdo->prepare('
         UPDATE guilds
-        SET gp_today = gp_today + p_gp,
-            gp_total = gp_total + p_gp
-        WHERE guild_id = p_guild_id
+        SET gp_today = gp_today + :gp,
+            gp_total = gp_total + :gp
+        WHERE guild_id = :guild_id
         LIMIT 1
     ');
     $stmt->bindValue(':guild_id', $guild_id, PDO::PARAM_INT);

--- a/http_server/queries/guilds/guild_insert.php
+++ b/http_server/queries/guilds/guild_insert.php
@@ -16,10 +16,10 @@ function guild_insert($pdo, $owner_id, $guild_name, $emblem, $note)
     $stmt->bindValue(':guild_name', $guild_name, PDO::PARAM_STR);
     $stmt->bindValue(':emblem', $emblem, PDO::PARAM_STR);
     $stmt->bindValue(':note', $note, PDO::PARAM_STR);
-
     $result = $stmt->execute();
+
     if ($result === false) {
-        throw new Exception('Could not create guild');
+        throw new Exception('Could not create guild.');
     }
 
     return $pdo->lastInsertId();

--- a/http_server/queries/guilds/guild_select.php
+++ b/http_server/queries/guilds/guild_select.php
@@ -12,12 +12,12 @@ function guild_select($pdo, $guild_id)
 
     $result = $stmt->execute();
     if ($result === false) {
-        throw new Exception('Could not fetch guild');
+        throw new Exception('Could not perform query guild_select.');
     }
 
     $guild = $stmt->fetch(PDO::FETCH_OBJ);
     if ($guild === false) {
-        throw new Exception('Guild not found');
+        throw new Exception('Could not find a guild with that ID.');
     }
 
     return $guild;

--- a/http_server/queries/guilds/guild_select_active_member_count.php
+++ b/http_server/queries/guilds/guild_select_active_member_count.php
@@ -12,7 +12,7 @@ function guild_select_active_member_count($pdo, $guild_id)
     $result = $stmt->execute();
 
     if ($result === false) {
-        throw new Exception('Could not perform query to select active member count');
+        throw new Exception('Could not determine active guild members.');
     }
 
     $row = $stmt->fetch(PDO::FETCH_OBJ);

--- a/http_server/queries/guilds/guild_select_by_name.php
+++ b/http_server/queries/guilds/guild_select_by_name.php
@@ -9,15 +9,16 @@ function guild_select_by_name($pdo, $guild_name)
         LIMIT 1
     ');
     $stmt->bindValue(':guild_name', $guild_name, PDO::PARAM_STR);
-
     $result = $stmt->execute();
+    
     if ($result === false) {
-        throw new Exception('Could not fetch guild by name');
+        throw new Exception('Could not perform query guild_select_by_name.');
     }
 
     $guild = $stmt->fetch(PDO::FETCH_OBJ);
+    
     if ($guild === false) {
-        throw new Exception('Guild not found');
+        throw new Exception('Could not find a guild with that name.');
     }
 
     return $guild;

--- a/http_server/queries/guilds/guilds_select_by_most_gp_today.php
+++ b/http_server/queries/guilds/guilds_select_by_most_gp_today.php
@@ -14,7 +14,7 @@ function guilds_select_by_most_gp_today($pdo)
 
     $result = $stmt->execute();
     if ($result === false) {
-        throw new Exception('Could not fetch top guilds');
+        throw new Exception('Could not perform query guilds_select_by_most_gp_today.');
     }
 
     return $stmt->fetchAll(PDO::FETCH_OBJ);

--- a/http_server/queries/guilds/guilds_select_by_most_gp_today.php
+++ b/http_server/queries/guilds/guilds_select_by_most_gp_today.php
@@ -3,9 +3,12 @@
 function guilds_select_by_most_gp_today($pdo)
 {
     $stmt = $pdo->prepare('
-        SELECT guild_id, guild_name, gp_today
+        SELECT guild_id, guild_name, gp_today, gp_total
         FROM guilds
-        ORDER BY gp_today DESC
+        WHERE member_count > 0
+        OR gp_today > 0
+        OR gp_total > 100
+        ORDER BY gp_today DESC, gp_total DESC
         LIMIT 50
     ');
 

--- a/http_server/queries/messages/message_delete.php
+++ b/http_server/queries/messages/message_delete.php
@@ -8,12 +8,12 @@ function message_delete($pdo, $user_id, $message_id)
         AND message_id = :message_id
         LIMIT 1
     ');
-    $stmt->bindValue(':user_id', $user_id, PDO::PARAM_INT);
+    $stmt->bindValue(':to_user_id', $user_id, PDO::PARAM_INT);
     $stmt->bindValue(':message_id', $message_id, PDO::PARAM_INT);
 
     $result = $stmt->execute();
-    if (!$result) {
-        throw new Exception('could not delete message');
+    if ($result === false) {
+        throw new Exception('Could not delete message.');
     }
 
     return $result;

--- a/http_server/queries/messages/message_select.php
+++ b/http_server/queries/messages/message_select.php
@@ -1,6 +1,6 @@
 <?php
 
-function message_select($pdo, $message_id)
+function message_select($pdo, $message_id, $suppress_error = false)
 {
     $stmt = $pdo->prepare('
         SELECT * FROM messages
@@ -11,12 +11,17 @@ function message_select($pdo, $message_id)
 
     $result = $stmt->execute();
     if (!$result) {
-        throw new Exception('could not select message');
+        throw new Exception('Could not perform query to select this message from the database.');
     }
 
     $message = $stmt->fetch(PDO::FETCH_OBJ);
-    if (!$message) {
-        throw new Exception('Message not found.');
+    if ($message === false) {
+        if ($suppress_error === false) {
+            throw new Exception('Message not found.');
+        }
+        else {
+            return false;
+        }
     }
 
     return $message;

--- a/http_server/queries/messages_reported/message_report_check_existing.php
+++ b/http_server/queries/messages_reported/message_report_check_existing.php
@@ -1,0 +1,24 @@
+<?php
+
+function message_report_check_existing($pdo, $message_id)
+{
+    $stmt = $pdo->prepare('
+        SELECT *
+        FROM messages_reported
+        WHERE message_id = :message_id
+    ');
+    $stmt->bindValue(':message_id', $message_id, PDO::PARAM_INT);
+    $result = $stmt->execute();
+    
+    if ($result === false) {
+        throw new Exception("Could not check if this message has been reported already.");
+    }
+    
+    $row = $stmt->fetchAll(PDO::FETCH_OBJ);
+    
+    if (count($row) == 0) {
+        return false;
+    }
+    
+    return true;
+}

--- a/http_server/queries/messages_reported/messages_reported_check_existing.php
+++ b/http_server/queries/messages_reported/messages_reported_check_existing.php
@@ -1,6 +1,6 @@
 <?php
 
-function message_report_check_existing($pdo, $message_id)
+function messages_reported_check_existing($pdo, $message_id)
 {
     $stmt = $pdo->prepare('
         SELECT *

--- a/http_server/queries/messages_reported/messages_reported_check_existing.php
+++ b/http_server/queries/messages_reported/messages_reported_check_existing.php
@@ -3,7 +3,7 @@
 function messages_reported_check_existing($pdo, $message_id)
 {
     $stmt = $pdo->prepare('
-        SELECT *
+        SELECT COUNT(*)
         FROM messages_reported
         WHERE message_id = :message_id
     ');
@@ -14,9 +14,9 @@ function messages_reported_check_existing($pdo, $message_id)
         throw new Exception("Could not check if this message has been reported already.");
     }
     
-    $row = $stmt->fetchAll(PDO::FETCH_OBJ);
+    $count = $stmt->fetchColumn();
     
-    if (count($row) == 0) {
+    if ($count == 0) {
         return false;
     }
     

--- a/http_server/queries/messages_reported/messages_reported_insert.php
+++ b/http_server/queries/messages_reported/messages_reported_insert.php
@@ -24,7 +24,7 @@ function messages_reported_insert($pdo, $to_user_id, $from_user_id, $reporter_ip
     $result = $stmt->execute();
 
     if ($result === false) {
-        throw new Exception('Could not send message');
+        throw new Exception('Could not report the message.');
     }
 
     return $result;

--- a/http_server/queries/recent_logins/recent_logins_select.php
+++ b/http_server/queries/recent_logins/recent_logins_select.php
@@ -1,21 +1,24 @@
 <?php
 
-function recent_logins_select($pdo, $user_id, $suppress_error = false, $count = 100)
+function recent_logins_select($pdo, $user_id, $suppress_error = false, $start = 0, $count = 100)
 {
+    $start = (int) $start;
     $count = (int) $count;
+    
     $stmt = $pdo->prepare('
         SELECT * FROM recent_logins
         WHERE user_id = :user_id
         ORDER BY date DESC
-        LIMIT 0 , :count
+        LIMIT :start , :count
     ');
     $stmt->bindValue(':user_id', $user_id, PDO::PARAM_INT);
+    $stmt->bindValue(':start', $start, PDO::PARAM_INT);
     $stmt->bindValue(':count', $count, PDO::PARAM_INT);
     $result = $stmt->execute();
 
-    if($result === false) {
+    if ($result === false) {
         if ($suppress_error === false) {
-            throw new Exception("Could not find any recent logins for this user.");
+            throw new Exception("Could not perform query recent_logins_select.");
         } else {
             return false;
         }

--- a/http_server/queries/tokens/token_delete.php
+++ b/http_server/queries/tokens/token_delete.php
@@ -3,22 +3,14 @@
 function token_delete ($pdo, $token)
 {
     $stmt = $pdo->prepare('
-        DECLARE _user_id INT(11);
-
-        SELECT user_id INTO _user_id
-        FROM tokens
-        WHERE token = :token;
-
         DELETE FROM tokens
-        WHERE user_id = _user_id;
-
-        SELECT _user_id;
+        WHERE token = :token
     ');
     $stmt->bindValue(':token', $token, PDO::PARAM_STR);
-
     $result = $stmt->execute();
+    
     if ($result === false) {
-        throw new Exception('Could not delete login token');
+        throw new Exception('Could not delete your login token from the database.');
     }
 
     return $result;

--- a/http_server/queries/users/user_select_guest.php
+++ b/http_server/queries/users/user_select_guest.php
@@ -3,7 +3,7 @@
 function user_select_guest($pdo)
 {
     $stmt = $pdo->prepare('
-        SSELECT user_id, name, email, register_ip, ip, time, register_time, power, status, read_message_id, guild, server_id
+        SELECT user_id, name, email, register_ip, ip, time, register_time, power, status, read_message_id, guild, server_id
         FROM users
         WHERE power = 0
         AND STATUS = "offline"

--- a/http_server/www/admin/guild_deep_info.php
+++ b/http_server/www/admin/guild_deep_info.php
@@ -62,9 +62,12 @@ function output_object($obj, $sep = '<br/>')
     if ($obj !== false) {
         foreach ($obj as $var => $val) {
             if ($var == 'name') {
-                $val = "<a href='player_deep_info.php?name1=$val'>$val</a>";
+                $safe_val = htmlspecialchars($val);
+                $url_val = urlencode($val);
+                $val = "<a href='player_deep_info.php?name1=$url_val'>$safe_val</a>";
+                echo "$var: $val".$sep;
             }
-            if ($var != 'guild_id') {
+            if ($var != 'guild_id' && $var != 'name') {
                 echo "$var: ".htmlspecialchars($val)."$sep";
             }
         }

--- a/http_server/www/admin/player_deep_info.php
+++ b/http_server/www/admin/player_deep_info.php
@@ -79,11 +79,12 @@ function output_object($obj, $sep = '<br/>')
         foreach ($obj as $var => $val) {
             if ($var == 'guild') {
                 $val = "<a href='guild_deep_info.php?guild_id=$val'>$val</a>";
+                echo "$var: $val $sep";
             }
             if ($var == 'time' || $var == 'register_time') {
                 $val = date('M j, Y g:i A', $val);
             }
-            if ($var != 'user_id') {
+            if ($var != 'user_id' && $var != 'guild') {
                 echo "$var: ".htmlspecialchars($val)."$sep";
             }
         }

--- a/http_server/www/admin/player_deep_logins.php
+++ b/http_server/www/admin/player_deep_logins.php
@@ -1,0 +1,129 @@
+<?php
+
+require_once __DIR__ . '/../../fns/all_fns.php';
+require_once __DIR__ . '/../../fns/output_fns.php';
+require_once __DIR__ . '/../../queries/users/user_select_by_name.php';
+require_once __DIR__ . '/../../queries/recent_logins/recent_logins_select.php';
+
+$user_name = find('name', '');
+$start = (int) default_get('start', 0);
+$count = (int) default_get('count', 250);
+
+// this will echo the search box when called
+function output_search($name = '', $incl_br = true)
+{
+    echo "<form name='input' action='' method='get'>";
+    echo "Username: <input type='text' name='name' value='$name'>&nbsp;";
+    echo "<input type='submit' value='Search'></form>";
+    if ($incl_br) {
+        echo "<br><br>";
+    }
+}
+
+// this will echo and control page counts when called
+function output_pagination($start, $count)
+{
+    $next_start_num = $start + $count;
+    $last_start_num = $start - $count;
+    if ($last_start_num < 0) {
+        $last_start_num = 0;
+    }
+    echo('<p>');
+    if ($start > 0) {
+        echo("<a href='?start=$last_start_num&count=$count'><- Last</a> |");
+    } else {
+        echo('<- Last |');
+    }
+    echo(" <a href='?start=$next_start_num&count=$count'>Next -></a></p>");
+}
+
+// admin check try block
+try {
+    //connect
+    $pdo = pdo_connect();
+
+    //make sure you're an admin
+    $admin = check_moderator($pdo, false, 3);
+} catch (Exception $e) {
+    $message = $e->getMessage();
+    output_header('Error');
+    echo "Error: $message";
+    output_footer();
+    die();
+}
+
+// admin validated try block
+try {
+    // header
+    output_header('Player Deep Logins', true, true);
+
+    // sanity check: no name in search box
+    if (is_empty($name)) {
+        output_search('', false);
+        output_footer();
+        die();
+    }
+    
+    // sanity check: ensure the database doesn't overload itself
+    if ($count > 500) {
+        $count = 500;
+    }
+
+    // if there's a name set, let's get data from the db
+    $user_id = name_to_id($pdo, $name);
+    $logins = recent_logins_select($pdo, $user_id, true, $start, $count);
+    
+    // calculate the number of results and the grammar to go with it
+    $num_results = count($logins);
+    if ($num_results == 1) {
+        $res = 'result';
+    } else {
+        $res = 'results';
+    }
+
+    // safety first
+    $safe_name = htmlspecialchars($name);
+
+    // show the search form
+    output_search($safe_name);
+    
+    if ($num_results > 0) {
+        output_pagination($start, $count);
+        echo '<p>---</p>';
+    }
+    
+    // output the number of results or kill the page if none
+    echo "$num_results $res logins recorded for the user \"$safe_name\".";
+    if ($num_results != 0) {
+        $end = $start + $count;
+        echo "<br>Showing results $start-$end<br><br>";
+    } else {
+        output_footer();
+        die();
+    }
+
+    // only gonna get here if there were results
+    foreach ($logins as $row) {
+        // make nice variables for our data
+        $ip = htmlspecialchars($row->ip); // ip
+        $country = htmlspecialchars($row->country); // country code
+        $date = htmlspecialchars($row->date); // date
+
+        // display the data
+        echo "IP: $ip | Country Code: $country | Date: $date<br>";
+    }
+    
+    // output page navigation
+    echo '<p>---</p>';
+    output_pagination($start, $count);
+
+    // end it all
+    output_footer();
+    die();
+} catch (Exception $e) {
+    $message = $e->getMessage();
+    output_search($safe_name);
+    echo "<i>Error: $message</i>";
+    output_footer();
+    die();
+}

--- a/http_server/www/admin/set_campaign.php
+++ b/http_server/www/admin/set_campaign.php
@@ -41,18 +41,6 @@ try {
     output_footer();
 }
 
-function get_level_info($campaign, $levelnum)
-{
-    $campaign_array = array();
-
-    foreach ($campaign->$levelnum as $level) {
-        ${"level_id_$levelnum"} = $campaign_array[$level->level_id];
-        ${"prize_type_$levelnum"} = $campaign_array[$level->prize_type];
-        ${"prize_id_$levelnum"} = $campaign_array[$level->prize_id];
-    }
-    return $campaign_array;
-}
-
 function is_selected($prize_type, $option_value)
 {
     $prize_type = strtolower($prize_type);
@@ -129,8 +117,6 @@ function output_form($pdo, $message)
     if ($message != '') {
         echo "<p><b>$message</b></p>";
     }
-
-    $level_info = get_level_info($campaign);
 
     echo '<form name="input" action="set_campaign.php" method="post">';
 

--- a/http_server/www/ban_user.php
+++ b/http_server/www/ban_user.php
@@ -110,7 +110,7 @@ try {
 
 
     // permission check
-    if ($mod_power <= $banned_power || $mod_power < 2) {
+    if ($banned_power >= 2 || $mod_power < 2) {
         throw new Exception("You lack the power to ban $banned_name.");
     }
 

--- a/http_server/www/guild_join.php
+++ b/http_server/www/guild_join.php
@@ -22,7 +22,7 @@ try {
 
     // gather information
     $user_id = token_login($pdo, false);
-    $account = user_select_expanded($pdo, $user_id);
+    $account = user_select_expanded($pdo, $guild_id);
     $guild = guild_select($pdo, $user_id);
 
     // sanity checks

--- a/http_server/www/guild_join.php
+++ b/http_server/www/guild_join.php
@@ -22,8 +22,8 @@ try {
 
     // gather information
     $user_id = token_login($pdo, false);
-    $account = user_select_expanded($pdo, $guild_id);
-    $guild = guild_select($pdo, $user_id);
+    $account = user_select_expanded($pdo, $user_id);
+    $guild = guild_select($pdo, $guild_id);
 
     // sanity checks
     if ($account->guild != 0) {

--- a/http_server/www/login.php
+++ b/http_server/www/login.php
@@ -16,7 +16,7 @@ require_once __DIR__ . '/../queries/rank_tokens/rank_token_select.php';
 require_once __DIR__ . '/../queries/rank_token_rentals/rank_token_rentals_count.php';
 require_once __DIR__ . '/../queries/staff/actions/mod_action_insert.php';
 require_once __DIR__ . '/../queries/friends/friends_select.php';
-require_once __DIR__ . '/../queries/ignored/ignored_select.php';
+require_once __DIR__ . '/../queries/ignored/ignored_select_list.php';
 require_once __DIR__ . '/../queries/exp_today/exp_today_select.php';
 require_once __DIR__ . '/../queries/guilds/guild_select.php';
 require_once __DIR__ . '/../queries/artifact/artifact_check.php';
@@ -139,7 +139,7 @@ try {
 
 
     // create variables from user data in db
-    $user_id = $user->user_id;
+    $user_id = (int) $user->user_id;
     $user_name = $user->name;
     $login->user_name = $user_name; // sanitize user input by taking name from the db to send to the server
     $group = $user->power;
@@ -255,7 +255,7 @@ try {
     }
 
     //--- get their ignored
-    $ignored_result = ignored_select($pdo, $user_id);
+    $ignored_result = ignored_select_list($pdo, $user_id);
     foreach ($ignored_result as $ir) {
         $ignored[] = $ir->ignore_id;
     }

--- a/http_server/www/mod/player_info.php
+++ b/http_server/www/mod/player_info.php
@@ -18,6 +18,12 @@ try {
     if (is_empty($user_id, false) && is_empty($force_ip) && is_empty($ip)) {
         throw new Exception("Invalid user ID specified.");
     }
+    
+    // detect mode
+    $ignore_user = false;
+    if ((!is_empty($ip) || !is_empty($force_ip)) && is_empty($user_id, false)) {
+        $ignore_user = true;
+    }
 
     // rate limiting
     rate_limit('mod-player-info-'.$mod_ip, 5, 2);
@@ -39,57 +45,59 @@ try {
     // header
     output_header('Player Info', true);
 
-    //get dem infos
-    $user = user_select($pdo, $user_id);
-    $pr2 = pr2_select($pdo, $user_id, true);
+    if ($ignore_user === false) {
+        // get dem infos
+        $user = user_select($pdo, $user_id);
+        $pr2 = pr2_select($pdo, $user_id, true);
 
-    // sanity check
-    if ($user == false || $pr2 == false) {
-        throw new Exception('Could not retrieve player info.');
-    }
-
-    // make neat variables
-    $rank = $pr2->rank;
-    $hat_array = $pr2->hat_array;
-    $hats = count(explode(',', $hat_array))-1;
-    $status = $user->status;
-    $ip = $user->ip;
-    $user_name = $user->name;
-
-    //--- count how many times they have been banned
-    $account_bans = bans_select_by_user_id($pdo, $user_id);
-    $account_ban_count = count($account_bans);
-    $account_ban_list = create_ban_list($account_bans);
-    if ($account_ban_count == 1) {
-        $s1 = '';
-    } else {
-        $s1 = 's';
-    }
-
-    //override ip
-    $overridden_ip = '';
-    if (isset($force_ip) && $force_ip != '') {
-        $overridden_ip = $ip;
-        $ip = $force_ip;
-    }
-
-    //check if they are currently banned
-    $banned = 'No';
-    $row = query_if_banned($pdo, $user_id, $ip);
-
-    //give some more info on the current ban in effect if there is one
-    if ($row !== false) {
-        $ban_id = $row->ban_id;
-        $reason = htmlspecialchars($row->reason);
-        $ban_end_date = date("F j, Y, g:i a", $row->expire_time);
-        if ($row->ip_ban == 1 && $row->account_ban == 1 && $row->banned_name == $user_name) {
-            $ban_type = 'account and ip are';
-        } elseif ($row->ip_ban == 1) {
-            $ban_type = 'ip is';
-        } elseif ($row->account_ban == 1) {
-            $ban_type = 'account is';
+        // sanity check
+        if ($user == false || $pr2 == false) {
+            throw new Exception('Could not retrieve player info.');
         }
-        $banned = "<a href='../bans/show_record.php?ban_id=$ban_id'>Yes.</a> This $ban_type banned until $ban_end_date. Reason: $reason";
+
+        // make neat variables
+        $rank = $pr2->rank;
+        $hat_array = $pr2->hat_array;
+        $hats = count(explode(',', $hat_array))-1;
+        $status = $user->status;
+        $ip = $user->ip;
+        $user_name = $user->name;
+
+        // count how many times they have been banned
+        $account_bans = bans_select_by_user_id($pdo, $user_id);
+        $account_ban_count = count($account_bans);
+        $account_ban_list = create_ban_list($account_bans);
+        if ($account_ban_count == 1) {
+            $s1 = '';
+        } else {
+            $s1 = 's';
+        }
+
+        //override ip
+        $overridden_ip = '';
+        if (isset($force_ip) && $force_ip != '') {
+            $overridden_ip = $ip;
+            $ip = $force_ip;
+        }
+
+        // check if they are currently banned
+        $banned = 'No';
+        $row = query_if_banned($pdo, $user_id, $ip);
+
+        //give some more info on the current ban in effect if there is one
+        if ($row !== false) {
+            $ban_id = $row->ban_id;
+            $reason = htmlspecialchars($row->reason);
+            $ban_end_date = date("F j, Y, g:i a", $row->expire_time);
+            if ($row->ip_ban == 1 && $row->account_ban == 1 && $row->banned_name == $user_name) {
+                $ban_type = 'account and ip are';
+            } elseif ($row->ip_ban == 1) {
+                $ban_type = 'ip is';
+            } elseif ($row->account_ban == 1) {
+                $ban_type = 'account is';
+            }
+            $banned = "<a href='../bans/show_record.php?ban_id=$ban_id'>Yes.</a> This $ban_type banned until $ban_end_date. Reason: $reason";
+        }
     }
 
 
@@ -105,7 +113,7 @@ try {
 
 
     //output the results
-    if (isset($user_id) && $user_id != 0) {
+    if ($ignore_user === false) {
         $html_user_name = htmlspecialchars($user_name);
         echo "<p>Name: <b>$html_user_name</b></p>"
         ."<p>IP: <del>".htmlspecialchars($overridden_ip)."</del> ".htmlspecialchars($ip)."</p>"

--- a/http_server/www/player_search.php
+++ b/http_server/www/player_search.php
@@ -3,6 +3,10 @@
 require_once __DIR__ . '/../fns/output_fns.php';
 require_once __DIR__ . '/../fns/all_fns.php';
 
+// pdo queries
+require_once __DIR__ . '/../queries/users/user_select_expanded.php'; // select expanded user data
+require_once __DIR__ . '/../queries/guilds/guild_select.php'; // select guild data
+
 $name = find_no_cookie("name", "");
 $ip = get_ip();
 
@@ -19,16 +23,15 @@ try {
     rate_limit("gui-player-search-" . $ip, 5, 1, "Wait a bit before searching again.");
     rate_limit("gui-player-search-" . $ip, 30, 5, "Wait a bit before searching again.");
 
-    // db
-    $db = new DB();
+    // connect
     $pdo = pdo_connect();
 
     // find user
-    $user = find_user($db, $pdo, $name);
+    $user = find_user($pdo, $name);
 
     // output
     output_search($name);
-    output_page($db, $user);
+    output_page($pdo, $user);
     output_footer();
 } catch (Exception $e) {
     $safe_error = htmlspecialchars($e->getMessage());
@@ -38,13 +41,13 @@ try {
     die();
 }
 
-function find_user($db, $pdo, $name)
+function find_user($pdo, $name)
 {
     // get id from name
     $user_id = name_to_id($pdo, $name);
 
     // get player info from id
-    $user = $db->grab_row('user_select_expanded', array($user_id));
+    $user = user_select_expanded($pdo, $user_id);
 
     return $user;
 }
@@ -69,7 +72,7 @@ function output_search($name = '')
 	";
 }
 
-function output_page($db, $user)
+function output_page($pdo, $user)
 {
 
     // sanity check: is the used tokens value set?
@@ -100,7 +103,7 @@ function output_page($db, $user)
 
     // guild id to name
     if ($guild_id !== 0) {
-        $guild = $db->grab_row('guild_select', array($guild_id));
+        $guild = guild_select($pdo, $guild_id);
         $guild_name = $guild->guild_name;
     } else {
         $guild_name = "<i>none</i>";

--- a/http_server/www/player_search.php
+++ b/http_server/www/player_search.php
@@ -114,7 +114,11 @@ function output_page($db, $user)
     // safety first
     $safe_name = htmlspecialchars($user_name);
     $safe_status = htmlspecialchars($status);
-    $safe_guild = htmlspecialchars($guild_name);
+    if ($guild_name == '<i>none</i>') {
+        $safe_guild = $guild_name;
+    } else {
+        $safe_guild = htmlspecialchars($guild_name);
+    }
 
     // --- Start the Page --- \\
 

--- a/http_server/www/player_search.php
+++ b/http_server/www/player_search.php
@@ -103,7 +103,7 @@ function output_page($db, $user)
         $guild = $db->grab_row('guild_select', array($guild_id));
         $guild_name = $guild->guild_name;
     } else {
-        $guild_name = '<i>none</i>';
+        $guild_name = "<i>none</i>";
     }
 
     // group html change if staff

--- a/http_server/www/register_user.php
+++ b/http_server/www/register_user.php
@@ -75,7 +75,8 @@ try {
     $db->call('pr2_insert', array($user_id));
 
     // compose a welcome pm
-    $welcome_message = "Welcome to Platform Racing 2, {htmlspecialchars($name)}!\n\n"
+    $safe_name = htmlspecialchars($name);
+    $welcome_message = "Welcome to Platform Racing 2, $safe_name!\n\n"
         ."<a href='https://grahn.io' target='_blank'><u><font color='#0000FF'>Click here</font></u></a> to read about the latest Platform Racing news on my blog.\n\n"
         ."If you have any questions or comments, send me an email at <a href='mailto:jacob@grahn.io?subject=Questions or Comments about PR2' target='_blank'><u><font color='#0000FF'>jacob@grahn.io</font></u></a>.\n\n"
         ."Thanks for playing, I hope you enjoy.\n\n"


### PR DESCRIPTION
Fixes:
 - HTML in assorted files
 - Display of IP-only bans on player_info.php
 - Message deletion, reporting (hopefully)
 - Admins being able to ban mods
 - Needlessly complicated syntax for `token_delete` (see note below)
 - `campaign_select_by_id`
 - Incrementing guild GP
 - Some more curly braces
 - Password-protected levels showing on title search

Addition:
 - `admin/player_deep_logins.php` - Allow admins to see all recorded logins by a user, separated by pages.

I also updated #93, which sorely needed an update.

This pull originally included a change to the friends/ignored queries, but you went ahead and fixed those so it's kinda useless now.  I took care of the merge conflicts, so this should have no problem merging automatically.

`token_delete` note: please make sure b9f5c1e won't break anything. It seems like the rest of the PDO query I removed is just redundant.

Side note, if `message_report.php` ever breaks again, I'm gonna punch myself in the face.