### PR TITLE
Revert queries back to pre-#298

### DIFF
--- a/http_server/fns/query_fns.php
+++ b/http_server/fns/query_fns.php
@@ -6,6 +6,12 @@ require_once __DIR__ . '/random_str.php';
 //--- checks if a login is valid -----------------------------------------------------------
 require_once __DIR__ . '/../queries/users/user_select_hash_by_name.php';
 require_once __DIR__ . '/../queries/users/user_apply_temp_pass.php';
+
+// user selection queries
+require_once __DIR__ . '/../queries/users/user_select.php'; // select full user by id
+require_once __DIR__ . '/../queries/users/user_select_by_name.php'; // select full user by name
+require_once __DIR__ . '/../queries/users/name_to_id.php'; // name -> id
+require_once __DIR__ . '/../queries/users/id_to_name.php'; // id -> name
 function pass_login($pdo, $name, $password)
 {
 
@@ -39,7 +45,7 @@ function pass_login($pdo, $name, $password)
     check_if_banned($pdo, $user->user_id, $ip);
 
     // respect changes to capitalization
-    $user->name = $name;
+    $user = user_select($pdo, $user->user_id);
 
     // done
     return $user;
@@ -72,13 +78,6 @@ function token_login($pdo, $use_cookie = true)
 
     return $user_id;
 }
-
-
-// user selection queries
-require_once __DIR__ . '/../queries/users/user_select.php'; // select full user by id
-require_once __DIR__ . '/../queries/users/user_select_by_name.php'; // select full user by name
-require_once __DIR__ . '/../queries/users/name_to_id.php'; // name -> id
-require_once __DIR__ . '/../queries/users/id_to_name.php'; // id -> name
 
 // part/epic upgrade queries
 require_once __DIR__ . '/../queries/epic_upgrades/epic_upgrades_select.php';

--- a/http_server/fns/query_fns.php
+++ b/http_server/fns/query_fns.php
@@ -10,8 +10,10 @@ require_once __DIR__ . '/../queries/users/user_apply_temp_pass.php';
 // user selection queries
 require_once __DIR__ . '/../queries/users/user_select.php'; // select full user by id
 require_once __DIR__ . '/../queries/users/user_select_by_name.php'; // select full user by name
+require_once __DIR__ . '/../queries/users/user_select_hash_by_name.php'; // select full user (with hashes) by name
 require_once __DIR__ . '/../queries/users/name_to_id.php'; // name -> id
 require_once __DIR__ . '/../queries/users/id_to_name.php'; // id -> name
+
 function pass_login($pdo, $name, $password)
 {
 
@@ -45,7 +47,7 @@ function pass_login($pdo, $name, $password)
     check_if_banned($pdo, $user->user_id, $ip);
 
     // respect changes to capitalization
-    $user = user_select($pdo, $user->user_id);
+    $user = user_select_hash_by_name($pdo, $user->user_id);
 
     // done
     return $user;

--- a/http_server/queries/users/user_select_hash_by_name.php
+++ b/http_server/queries/users/user_select_hash_by_name.php
@@ -3,7 +3,7 @@
 function user_select_hash_by_name($pdo, $name)
 {
     $stmt = $pdo->prepare('
-        SELECT pass_hash, temp_pass_hash, user_id
+        SELECT *
           FROM users
          WHERE name = :name
          LIMIT 1


### PR DESCRIPTION
Reverting the `users_select_hash_by_name` query to what it was before my changes, then changing `user_select` in `query_fns.php` back to `users_select_hash_by_name`.