### PR TITLE
Fix action logging, expire old email change/guild transfer requests

### DIFF
--- a/http_server/cron/daily.php
+++ b/http_server/cron/daily.php
@@ -14,6 +14,8 @@ require_once __DIR__ . '/../queries/rank_token_rentals/rank_token_rentals_delete
 require_once __DIR__ . '/../queries/tokens/tokens_delete_old.php';
 require_once __DIR__ . '/../queries/servers/servers_select.php';
 require_once __DIR__ . '/../queries/users/users_reset_status.php';
+require_once __DIR__ . '/../queries/guild_transfers/guild_transfers_expire_old.php';
+require_once __DIR__ . '/../queries/changing_emails/changing_emails_expire_old.php';
 
 $pdo = pdo_connect();
 $servers = servers_select($pdo);
@@ -32,6 +34,8 @@ gp_reset($pdo);
 rank_token_rentals_delete_old($pdo);
 tokens_delete_old($pdo);
 users_reset_status($pdo);
+guild_transfers_expire_old($pdo);
+changing_emails_expire_old($pdo);
 
 output('result=ok');
 

--- a/http_server/queries/changing_emails/changing_emails_expire_old.php
+++ b/http_server/queries/changing_emails/changing_emails_expire_old.php
@@ -1,0 +1,17 @@
+<?php
+
+function changing_emails_expire_old($pdo)
+{
+    $result = $pdo->exec('
+        UPDATE changing_emails
+           SET status = "expired",
+               confirm_ip = "n/a"
+         WHERE DATE(date) < DATE_SUB(NOW(), INTERVAL 1 DAY)
+    ');
+    
+    if ($result === false) {
+        throw new Exception('Could not expire old email changes.');
+    }
+    
+    return $result;
+}

--- a/http_server/queries/guild_transfers/guild_transfers_expire_old.php
+++ b/http_server/queries/guild_transfers/guild_transfers_expire_old.php
@@ -1,0 +1,17 @@
+<?php
+
+function guild_transfers_expire_old($pdo)
+{
+    $result = $pdo->exec('
+        UPDATE guild_transfers
+           SET status = "expired",
+               confirm_ip = "n/a"
+         WHERE DATE(date) < DATE_SUB(NOW(), INTERVAL 1 DAY)
+    ');
+    
+    if ($result === false) {
+        throw new Exception('Could not expire old guild transfers.');
+    }
+    
+    return $result;
+}

--- a/http_server/www/admin/player_deep_logins.php
+++ b/http_server/www/admin/player_deep_logins.php
@@ -116,8 +116,8 @@ try {
     }
     
     if ($login_count > 0 && count($logins) > 0) {
-        output_pagination($start, $count, $name, $is_end);
         echo '<p>---</p>';
+        output_pagination($start, $count, $name, $is_end);
     }
 
     // only gonna get here if there were results
@@ -134,7 +134,6 @@ try {
     // output page navigation
     if ($login_count > 0 && count($logins) > 0) {
         output_pagination($start, $count, $name, $is_end);
-        echo '<p>---</p>';
     }
 
     // end it all

--- a/http_server/www/admin/set_campaign.php
+++ b/http_server/www/admin/set_campaign.php
@@ -189,16 +189,11 @@ function update($pdo)
     // push the changes to the servers
     generate_level_list($pdo, 'campaign');
 
-    try {
-        //admin log
-        $admin_name = $admin->name;
-        $admin_id = $admin->user_id;
-        $ip = get_ip();
-        admin_action_insert($pdo, $admin_id, "$admin_name set a new custom campaign from $ip.", $admin_id, $ip);
-    } catch (Exception $e) {
-        $message = "Error: " . $e->getMessage();
-        output_form($pdo, $message);
-    }
+    //admin log
+    $admin_name = $admin->name;
+    $admin_id = $admin->user_id;
+    $ip = get_ip();
+    admin_action_insert($pdo, $admin_id, "$admin_name set a new custom campaign from $ip.", 0, $ip);
 
     // did the script get here? great! redirect back to the script with a success message
     $message = "Great success! The new campaign has been set and will take effect shortly.";

--- a/http_server/www/admin/update_account.php
+++ b/http_server/www/admin/update_account.php
@@ -177,12 +177,12 @@ function update($pdo, $admin)
 
     // adjust guild member count
     if ($user->guild != $guild_id) {
-        guild_select($pdo, $guild_id); // make sure the new guild exists
+        if ($guild_id != 0) {
+            guild_select($pdo, $guild_id); // make sure the new guild exists
+            guild_increment_member($pdo, $user->guild, 1);
+        }
         if ($user->guild != 0) {
             guild_increment_member($pdo, $user->guild, -1);
-        }
-        if ($guild_id != 0) {
-            guild_increment_member($pdo, $user->guild, 1);
         }
     }
 
@@ -219,7 +219,7 @@ function update($pdo, $admin)
     $admin_name = $admin->name;
     $admin_id = $admin->user_id;
     $disp_changes = "Changes: " . $account_changes;
-    admin_action_insert($pdo, $admin_id, "$admin_name updated player $user_name from $admin_ip. (update_user: $updated_user, update_pr2: $updated_pr2, update_epic: $updated_epic, changes: $account_changes)", 'update_account', $admin_ip);
+    admin_action_insert($pdo, $admin_id, "$admin_name updated player $user_name from $admin_ip. {update_user: $updated_user, update_pr2: $updated_pr2, update_epic: $updated_epic, changes: $account_changes}", 0, $admin_ip);
 
     header("Location: player_deep_info.php?name1=" . urlencode($user_name));
     die();

--- a/http_server/www/admin/update_guild.php
+++ b/http_server/www/admin/update_guild.php
@@ -151,7 +151,7 @@ function update($pdo, $admin)
     $admin_name = $admin->name;
     $admin_id = $admin->user_id;
     $disp_changes = "Changes: " . $guild_changes;
-    admin_action_insert($pdo, $admin_id, "$admin_name updated guild $guild_id from $admin_ip. $disp_changes.", 'update_guild', $admin_ip);
+    admin_action_insert($pdo, $admin_id, "$admin_name updated guild $guild_id from $admin_ip. $disp_changes.", 0, $admin_ip);
 
     // redirect
     header("Location: guild_deep_info.php?guild_id=" . urlencode($guild->guild_id));

--- a/http_server/www/ban_user.php
+++ b/http_server/www/ban_user.php
@@ -139,9 +139,6 @@ try {
         $disp_reason = "no reason given";
     }
 
-    // get mod's IP
-    $ip = $mod->ip;
-
     // make account/ip ban detection pretty courtesy of data_fns.php
     $is_account_ban = check_value($safe_account_ban, 1);
     $is_ip_ban = check_value($safe_ip_ban, 1);
@@ -149,11 +146,8 @@ try {
     // make expire time pretty
     $disp_expire_time = date('Y-m-d H:i:s', $expire_time);
 
-    // action log string
-    $action_string = "$mod_user_name banned $banned_name from $ip (duration: $disp_duration, account_ban: $is_account_ban, ip_ban: $is_ip_ban, expire_time: $disp_expire_time, $disp_reason)";
-
     //record the ban in the action log
-    mod_action_insert($pdo, $mod_user_id, $action_string, 'ban', $ip);
+    mod_action_insert($pdo, $mod_user_id, "$mod_user_name banned $banned_name from $ip {duration: $disp_duration, account_ban: $is_account_ban, ip_ban: $is_ip_ban, expire_time: $disp_expire_time, $disp_reason}", 0, $ip);
 
     if ($using_mod_site == 'yes' && $redirect == 'yes') {
         header('Location: //pr2hub.com/mod/player_info.php?user_id='.$banned_user_id.'&force_ip='.$force_ip);

--- a/http_server/www/guild_delete.php
+++ b/http_server/www/guild_delete.php
@@ -1,11 +1,11 @@
 <?php
 
-require_once __DIR__ . '/../fns/all_fns.php';
-require_once __DIR__ . '/../queries/guilds/guild_delete.php';
-require_once __DIR__ . '/../queries/guilds/guild_select.php';
-require_once __DIR__ . '/../queries/staff/actions/mod_action_insert.php';
-
 header("Content-type: text/plain");
+
+require_once __DIR__ . '/../fns/all_fns.php';
+require_once __DIR__ . '/../queries/guilds/guild_select.php'; // select a guild
+require_once __DIR__ . '/../queries/guilds/guild_delete.php'; // delete a guild
+require_once __DIR__ . '/../queries/staff/actions/mod_action_insert.php'; // record the mod action
 
 $guild_id = find_no_cookie('guild_id');
 $ip = get_ip();
@@ -21,7 +21,6 @@ try {
     $mod = check_moderator($pdo);
     $mod_name = $mod->name;
     $mod_id = $mod->user_id;
-    $ip = $mod->ip;
 
     // more rate limiting
     rate_limit('guild-delete-'.$mod_id, 5, 2);
@@ -36,7 +35,7 @@ try {
     guild_delete($pdo, $guild_id);
 
     // record the deletion in the action log
-    mod_action_insert($pdo, $mod_id, "$mod_name deleted guild $guild_id from $ip (guild_name: $guild_name, guild_prose: $guild_note, owner_id: $guild_owner)", $mod_id, $ip);
+    mod_action_insert($pdo, $mod_id, "$mod_name deleted guild $guild_id from $ip {guild_name: $guild_name, guild_prose: $guild_note, owner_id: $guild_owner}", 0, $ip);
 
     // safety first
     $safe_guild_name = htmlspecialchars($guild_name);

--- a/http_server/www/mod/archive_message.php
+++ b/http_server/www/mod/archive_message.php
@@ -5,7 +5,7 @@ require_once __DIR__ . '/../../fns/output_fns.php';
 require_once __DIR__ . '/../../queries/staff/actions/mod_action_insert.php';
 require_once __DIR__ . '/../../queries/messages_reported/messages_reported_archive.php';
 
-$message_id = (int) default_val($_GET['message_id'], 0);
+$message_id = (int) default_get('message_id', 0);
 $ip = get_ip();
 
 try {
@@ -29,12 +29,9 @@ try {
     // archive the message
     messages_reported_archive($pdo, $message_id);
 
-    // action log
-    $name = $mod->name;
-    $ip = $mod->ip;
-
     // record the change
-    mod_action_insert($pdo, $mod->user_id, "$name archived the report of PM $message_id from $ip", $mod->user_id, $ip);
+    $name = $mod->name;
+    mod_action_insert($pdo, $mod->user_id, "$name archived the report of PM $message_id from $ip.", 0, $ip);
 
     // tell the sorry saps trying to debug
     $ret = new stdClass();

--- a/http_server/www/mod/archive_message.php
+++ b/http_server/www/mod/archive_message.php
@@ -30,8 +30,9 @@ try {
     messages_reported_archive($pdo, $message_id);
 
     // record the change
-    $name = $mod->name;
-    mod_action_insert($pdo, $mod->user_id, "$name archived the report of PM $message_id from $ip.", 0, $ip);
+    $mod_id = $mod->user_id;
+    $mod_name = $mod->name;
+    mod_action_insert($pdo, $mod_id, "$mod_name archived the report of PM $message_id from $ip.", 0, $ip);
 
     // tell the sorry saps trying to debug
     $ret = new stdClass();

--- a/http_server/www/mod/ban_edit.php
+++ b/http_server/www/mod/ban_edit.php
@@ -91,7 +91,9 @@ function update($pdo, $mod, $ban_id, $ip)
     }
 
     // record the change
-    mod_action_insert($pdo, $mod->user_id, "$mod->name edited ban $ban_id from $ip (account_ban: $is_account_ban, ip_ban: $is_ip_ban, expire_time: $expire_time, $disp_notes)", "ban_edit", $ip);
+    $mod_id = $mod->user_id;
+    $mod_name = $mod->name;
+    mod_action_insert($pdo, $mod_id, "$mod_name edited ban $ban_id from $ip {account_ban: $is_account_ban, ip_ban: $is_ip_ban, expire_time: $expire_time, $disp_notes}", 0, $ip);
 
     // redirect to the ban listing
     header("Location: https://pr2hub.com/bans/show_record.php?ban_id=$ban_id");

--- a/http_server/www/mod/do_lift_ban.php
+++ b/http_server/www/mod/do_lift_ban.php
@@ -5,8 +5,8 @@ require_once __DIR__ . '/../../fns/output_fns.php';
 require_once __DIR__ . '/../../queries/bans/ban_lift.php';
 require_once __DIR__ . '/../../queries/staff/actions/mod_action_insert.php';
 
-$ban_id = (int) default_val($_POST['ban_id'], 0);
-$reason = default_val($_POST['reason'], 'They bribed me with skittles!');
+$ban_id = (int) default_post('ban_id', 0);
+$reason = default_post('reason', 'They bribed me with skittles!');
 $ip = get_ip();
 
 try {

--- a/http_server/www/mod/do_lift_ban.php
+++ b/http_server/www/mod/do_lift_ban.php
@@ -43,6 +43,7 @@ try {
 
     //record the change
     $user_id = $mod->user_id;
+    $name = $mod->name;
     if ($reason != '') {
         $disp_reason = "Reason: " . htmlspecialchars($reason);
     } else {

--- a/http_server/www/remove_level.php
+++ b/http_server/www/remove_level.php
@@ -3,11 +3,9 @@
 header("Content-type: text/plain");
 
 require_once __DIR__ . '/../fns/all_fns.php';
-
-require_once __DIR__ . '/../queries/levels/level_select.php';
-require_once __DIR__ . '/../queries/staff/level_unpublish.php';
-
-require_once __DIR__ . '/../queries/staff/actions/mod_action_insert.php';
+require_once __DIR__ . '/../queries/levels/level_select.php'; // select a level
+require_once __DIR__ . '/../queries/staff/level_unpublish.php'; // unpublish a level
+require_once __DIR__ . '/../queries/staff/actions/mod_action_insert.php'; // record the mod action
 
 $level_id = (int) default_post('level_id', 0);
 
@@ -52,10 +50,9 @@ try {
     $name = $mod->name;
     $user_id = $mod->user_id;
     $ip = $mod->ip;
-    $action_string = "$name unpublished level $level_id from $ip (level_title: $l_title, creator: $l_creator, level_note: $l_note)";
     
     //record the change
-    mod_action_insert($pdo, $user_id, $action_string, 'remove_level', $ip);
+    mod_action_insert($pdo, $user_id, "$name unpublished level $level_id from $ip {level_title: $l_title, creator: $l_creator, level_note: $l_note}", 0, $ip);
     
     //tell it to the world
     die('message=This level has been removed successfully. It may take up to 60 seconds for this change to take effect.');


### PR DESCRIPTION
This update fixes action logging.  It also expires email change and guild transfer requests older than a day for security purposes.  Feel free to change the amount of time on that if you'd like, but I think that the least amount of time the changes are valid, the bigger a win for security.