### PR TITLE
Remove final references to Lux, repurpose Moon Hat

### DIFF
--- a/multiplayer_server/Player.php
+++ b/multiplayer_server/Player.php
@@ -95,7 +95,6 @@ class Player
 
     public $status = '';
 
-    public $lux = 0;
     public $lives = 3;
     public $items_used = 0;
     public $super_booster = false;
@@ -1149,8 +1148,6 @@ class Player
 
         $status = $this->status;
         $e_server_id = $server_id;
-
-        $this->lux = 0;
 
         $rt_used = $this->rt_used;
         $ip = $this->ip;

--- a/multiplayer_server/Player.php
+++ b/multiplayer_server/Player.php
@@ -323,27 +323,9 @@ class Player
 
         // make sure they're in exactly one valid room
         if ($room_type != 'n' && $room_type != 'b' && isset($player_room)) {
-            // guest check
-            if ($this->group <= 0 || $this->guest == true) {
-                $this->write('systemChat`Sorries, guests can\'t send chat messages.');
-            } // chat ban check (warnings, auto-warn)
-            elseif ($this->chat_ban > time()) {
-                $this->write(
-                    'systemChat`You have been temporarily banned from the chat. '
-                    .'The ban will be lifted in '.($this->chat_ban - time()).' seconds.'
-                );
-            } // spam check
-            elseif ($this->get_chat_count() > 6) {
-                $this->chat_ban = time() + 60;
-                $this->write('systemChat`Slow down a bit, yo.');
-            } // rank 3 check
-            elseif ($this->active_rank < 3) {
-                $this->write('systemChat`Sorries, you must be rank 3 or above to chat.');
-            } // illegal character check
-            elseif (strpos($chat_message, '`') !== false) {
-                $this->write('message`Error: Illegal character in message.');
-            } // tournament mode
-            elseif (strpos($chat_message, '/t ') === 0 || strpos($chat_message, '/tournament ') === 0 || $chat_message == '/t' || $chat_message == '/tournament') {
+            // --- chat commands --- \\
+            // tournament mode
+            if (strpos($chat_message, '/t ') === 0 || strpos($chat_message, '/tournament ') === 0 || $chat_message == '/t' || $chat_message == '/tournament') {
                 // if server owner, allow them to do server owner things
                 if ($this->server_owner == true) {
                     // help
@@ -659,7 +641,7 @@ class Player
                 } else {
                     $this->write("Invalid action. For more information on how to use this command, type /mod help.");
                 }
-            }
+            } // rules command
             elseif ($chat_message == '/rules') {
                 $message = 'systemChat`The PR2 rules can be found here: https://jiggmin2.com/forums/showthread.php?tid=385.';
                 if ($guild_id != 0) {
@@ -690,11 +672,28 @@ class Player
                     }
                     $this->write('systemChat`PR2 Chat Commands:<br>- /rules<br>- /view *player*<br>- /guild *guild name*<br>- /hint (Artifact)<br>- /hh status<br>- /t status<br>- /population<br>- /beawesome'.$mod.$effects.$admin.$server_owner);
                 }
-            } // send chat message
+            } // --- send chat message --- \\
             else {
-                if (strpos($this->name, '`') !== false) {
-                    $this->write('message`Error: Illegal character in username.');
-                } else {
+                // guest check
+                if ($this->group <= 0 || $this->guest == true) {
+                    $this->write("systemChat`Sorries, guests can't send chat messages.");
+                } // rank 3 check
+                elseif ($this->active_rank < 3 && $this->group < 2) {
+                    $this->write('systemChat`Sorries, you must be rank 3 or above to chat.');
+                } // chat ban check (warnings, auto-warn)
+                elseif ($this->chat_ban > time() && ($this->group < 2 || $this->temp_mod === true)) {
+                    $chat_ban_seconds = $this->chat_ban - time();
+                    $this->write('systemChat`You have been temporarily banned from the chat. The ban will be lifted in $chat_ban_seconds seconds.');
+                } // spam check
+                elseif ($this->get_chat_count() > 6 && ($this->group < 2 || $this->temp_mod === true)) {
+                    $this->chat_ban = time() + 60;
+                    $this->write('systemChat`Slow down a bit, yo.');
+                }
+                // illegal character in username/message check
+                elseif (strpos($this->name, '`') !== false || strpos($chat_message, '`') !== false) {
+                    $this->write('message`Error: Illegal character detected.');
+                } // if caught by NOTHING above, send the message
+                else {
                     $message = 'chat`'.$this->name.'`'.$this->group.'`'.$chat_message;
                     $this->chat_count++;
                     $this->chat_time = time();
@@ -703,13 +702,13 @@ class Player
             }
         } // this should never happen
         elseif ($room_type == 'b') {
-            $this->write('message`Error: You can\'t be in two places at once!');
+            $this->write("message`Error: You can't be in two places at once!");
         } // this should also never happen
         elseif ($room_type == 'n') {
-            $this->write('message`Error: You don\'t seem to be in a valid chatroom.');
+            $this->write("message`Error: You don't seem to be in a valid chatroom.");
         } // aaaaand this most certainly will never happen
         else {
-            $this->write('message`Error: The server encountered an error when trying to determine what chatroom you\'re in. Try rejoining the chatroom and sending your message again.');
+            $this->write("message`Error: The server encountered an error when trying to determine what chatroom you're in. Try rejoining the chatroom and sending your message again. If this error persists, contact a member of the PR2 Staff Team.");
         }
     }
 

--- a/multiplayer_server/rooms/Game.php
+++ b/multiplayer_server/rooms/Game.php
@@ -423,13 +423,19 @@ class Game extends Room
         $this->finish_race($player);
     }
 
+    
+    private function ensure_time_format($time) {
+        if ($time < 0) $time = 0;
+        return round($time, 2);
+    }
+    
 
     public function finish_race($player)
     {
         global $pdo;
 
         if ($player->finished_race === false && !isset($player->race_stats->finish_time) && $player->race_stats->drawing === false && $this->begun === true) {
-            $finish_time = microtime(true) - $this->start_time;
+            $finish_time = $this->ensure_time_format(microtime(true) - $this->start_time);
             $this->set_finish_time($player, $finish_time);
 
             $time_mod = $finish_time / 120;
@@ -439,11 +445,9 @@ class Game extends Room
 
             $place = array_search($player->race_stats, $this->finish_array);
 
-            if ($place == 0 && count($this->finish_array) > 1 && $finish_time > 10) {
-                $this->give_gp($player);
-                if (pr2_server::$tournament) {
-                    $this->broadcast_results($player);
-                }
+            // announce on tournament server
+            if ($place == 0 && count($this->finish_array) > 1 && $finish_time > 10 && pr2_server::$tournament) {
+                $this->broadcast_results($player, $finish_time);
             }
 
             //--- prize -----------
@@ -467,7 +471,6 @@ class Game extends Room
 
             //--- exp gain -------
             $tot_exp_gain = 0;
-            $tot_lux_gain = 0;
             $wearing_moon = false;
 
             //--- welcome back bonus ---
@@ -536,20 +539,23 @@ class Game extends Room
                 $tot_exp_gain += $tot_exp_gain * $hat_bonus;
             }
 
-            if ($finish_time >= 90 && $wearing_moon) {
-                $tot_lux_gain = count($this->finish_array) - $place - 1;
+            // gp bonus
+            if ($place == 0 && count($this->finish_array) > 1 && $finish_time > 10) {
+                if ($wearing_moon === true) {
+                    $this->give_gp($player, 2);
+                } else {
+                    $this->give_gp($player);
+                }
             }
 
             // happy hour bonus
             if (HappyHour::isActive()) {
                 $tot_exp_gain *= 2;
-                $tot_lux_gain *= 2;
             }
 
             // campaign bonus
             if (isset($this->campaign)) {
                 $tot_exp_gain *= 2;
-                $tot_lux_gain *= 2;
             }
 
             // tell the user about the hat/hh/campaign bonus(es)
@@ -602,12 +608,6 @@ class Game extends Room
             //---
             $player->inc_exp($tot_exp_gain);
 
-            //lux gain
-            if ($tot_lux_gain > 0) {
-                $player->write('setLuxGain`'.$tot_lux_gain);
-                $player->lux += $tot_lux_gain;
-            }
-
             //--- save
             $player->maybe_save();
         } else {
@@ -622,9 +622,10 @@ class Game extends Room
 
 
 
-    private function broadcast_results($player)
+    private function broadcast_results($player, $finish_time)
     {
         global $chat_room_array;
+        $finish_time = date("H:i:s.u", $finish_time);
 
         if (isset($chat_room_array['main'])) {
             $main = $chat_room_array['main'];
@@ -634,7 +635,7 @@ class Game extends Room
                 $names[] = "[$race_stats->name]";
             }
             $vs_names = join(' vs ', $names);
-            $message = "$vs_names: // $player->name wins!";
+            $message = "$vs_names: // $player->name wins with a time of $finish_time!";
             $main->send_chat("systemChat`$message", -1);
         }
     }
@@ -763,11 +764,11 @@ class Game extends Room
 
 
 
-    private function give_gp($player)
+    private function give_gp($player, $multiplier = 1)
     {
         $user_id = $player->user_id;
         $prev_gp = GuildPoints::get_previous_gp($user_id, $this->course_id);
-        $earned_gp = floor($player->race_stats->finish_time / 60 * count($this->player_array) / 4);
+        $earned_gp = floor($player->race_stats->finish_time / 60 * count($this->player_array) / 4) * $multiplier;
         if ($prev_gp + $earned_gp > 10) {
             $earned_gp -= ( $prev_gp + $earned_gp ) - 10;
         }


### PR DESCRIPTION
Some small updates:
 - Remove all references to Lux, as it's no longer used.
 - Make the moon hat give double GP.
 - Add the time in which a level was defeated to the chat message during tournament mode.
 - Move some code in Player.php to let guests/users less than rank 3 use chat commands.