### PR TITLE
Enable referer check

### DIFF
--- a/http_server/www/admin/set_campaign.php
+++ b/http_server/www/admin/set_campaign.php
@@ -26,7 +26,7 @@ try {
 
 
     // make sure you're an admin
-    $admin = check_moderator($pdo, false, 3);
+    $admin = check_moderator($pdo, true, 3);
 
 
     // lookup


### PR DESCRIPTION
Enable referer check to prevent CSRF exploit that would allow to force change campaign.