### PR TITLE
Prohibit backtick in race chats

### DIFF
--- a/multiplayer_server/rooms/Game.php
+++ b/multiplayer_server/rooms/Game.php
@@ -864,6 +864,10 @@ class Game extends Room
 
     public function send_chat($message, $user_id)
     {
+        if (strpos($message, '`') !== false) {
+            $player->socket->write('message`Error: Illegal character in message.');
+            return false;
+        }
         foreach ($this->player_array as $player) {
             if (!$player->is_ignored_id($user_id)) {
                 $player->socket->write($message);

--- a/multiplayer_server/rooms/Game.php
+++ b/multiplayer_server/rooms/Game.php
@@ -864,13 +864,18 @@ class Game extends Room
 
     public function send_chat($message, $user_id)
     {
-        if (strpos($message, '`') !== false) {
+        if (strpos($message, 'chat`') !== 0) {
+            $player->socket->write('message`Error: Illegal character in message.');
+            return false;
+        }
+        $chat_message = substr($chat_message, 5);
+        if (strpos($chat_message, '`') !== false) {
             $player->socket->write('message`Error: Illegal character in message.');
             return false;
         }
         foreach ($this->player_array as $player) {
             if (!$player->is_ignored_id($user_id)) {
-                $player->socket->write($message);
+                $player->socket->write("chat`$chat_message");
             }
         }
     }


### PR DESCRIPTION
This prevents socket commands other than `` chat` `` from being executed via the chat box. To take effect, this pull requires restarting all servers.

Thanks to @BrokenBulb78 for bringing this to my attention! \o/