### PR TITLE
Actually fix leaderboard, guild search

### DIFF
--- a/http_server/queries/users/users_select_top.php
+++ b/http_server/queries/users/users_select_top.php
@@ -10,7 +10,8 @@ function users_select_top($pdo, $start, $count)
           FROM users u
           LEFT JOIN pr2 ON pr2.user_id = u.user_id
           LEFT JOIN rank_tokens rt ON rt.user_id = pr2.user_id
-         WHERE rank > 44
+         WHERE pr2.rank > 44
+         GROUP BY name, power, pr2.rank, rt.used_tokens, hats
         HAVING active_rank > 49
          ORDER BY active_rank DESC, name ASC
          LIMIT :start, :count

--- a/http_server/www/guild_search.php
+++ b/http_server/www/guild_search.php
@@ -132,6 +132,8 @@ try {
             // end the row, move on to the next member
             echo '</tr>';
         }
+        // end the table
+        echo '</table>';
     }
 } catch(Exception $e) {
     $safe_error = htmlspecialchars($e->getMessage());

--- a/http_server/www/guild_search.php
+++ b/http_server/www/guild_search.php
@@ -9,7 +9,7 @@ require_once __DIR__ . '/../queries/users/user_select_name_and_power.php';
 
 $group_colors = ['7e7f7f', '047b7b', '1c369f', '870a6f'];
 
-$guild_name = $_GET['name'];
+$guild_name = default_get('name', '');
 $guild_id = (int) default_get('id', 0);
 $ip = get_ip();
 
@@ -30,27 +30,23 @@ try {
     $pdo = pdo_connect();
 
     // if by name, get id
+    $mode = 'id';
     if (!is_empty($guild_name) && is_empty($guild_id, false)) {
+        $mode = 'name';
         $guild_id = (int) guild_name_to_id($pdo, $guild_name);
     }
     
     // start the page
     output_header("Guild Search");
     
-    // output the search box
-    output_search($guild_name, $guild_id);
-    
-    // center the page
-    echo '<center>';
-    
     // get guild info
     $guild = guild_select($pdo, $guild_id);
     
     // make some variables
     $guild_id = (int) $guild->guild_id;
-    $guild_name = htmlspecialchars($guild->name);
-    $creation_date = date('j/M/Y', $guild->creation_date);
-    $active_date = date('j/M/Y', $guild->active_date);
+    $guild_name = htmlspecialchars($guild->guild_name);
+    $creation_date = date('j/M/Y', strtotime($guild->creation_date));
+    $active_date = date('j/M/Y', strtotime($guild->active_date));
     $member_count = (int) $guild->member_count;
     $emblem = $guild->emblem;
     $gp_today = (int) $guild->gp_total;
@@ -69,10 +65,11 @@ try {
         $emblem = str_replace('.j', '.jpg', $emblem);
     }
     
-    // simple text replacement
-    if ($member_count === 0) {
-        $member_count = 'none';
-    }
+    // output the search box
+    output_search($guild_name, $guild_id, $mode);
+    
+    // center the page
+    echo '<center>';
     
     // display guild info
     echo "<br>-- <b>$guild_name</b> --<br>";
@@ -82,9 +79,9 @@ try {
     echo '<br>'
         ."<img src='https://pr2hub.com/emblems/$emblem'>"
         .'<br><br>'
-        ."Owner: <a href='player_search.php?name=$owner_url_name' style='color: $owner_color; text-decoration: underline;'>$owner_name</a><br>"
-        ."Members: $member_count ($active_count active)<br>"
-        ."GP Today: $gp_today<br>"
+        ."Owner: <a href='player_search.php?name=$owner_url_name' style='color: #$owner_color; text-decoration: underline;'>$owner_name</a><br>"
+        ."Members: $member_count | Active: $active_count<br>"
+        ."GP Today: $gp_today | "
         ."GP Total: $gp_total<br>"
         ."Created: $creation_date<br>"
         ."Last Active: $active_date<br>";
@@ -115,7 +112,7 @@ try {
             
             // if the guild owner, display a crown next to their name
             if ($member_id === $owner_id) {
-                echo '<img src="/img/vault/Crown-40x40.png" height="12">';
+                echo '<img src="img/vault/Crown-40x40.png" height="12" title="Guild Owner"> ';
             }
             
             // member name column
@@ -145,8 +142,24 @@ try {
     die();
 }
 
-function output_search($guild_name = '', $guild_id = '') {
+function output_search($guild_name = '', $guild_id = '', $mode = NULL) {
     $guild_id = (int) $guild_id;
+    
+    // choose which one to set after searching
+    $id_display = 'none';
+    $name_display = 'none';
+    $id_checked = '';
+    $name_checked = '';
+    switch($mode) {
+        case 'id':
+            $id_display = 'block';
+            $id_checked = 'checked="checked"';
+            break;
+        case 'name':
+            $name_display = 'block';
+            $name_checked = 'checked="checked"';
+            break;
+    }
 
     // check if values passed are empty
     if (is_empty($guild_name)) $guild_name = '';
@@ -174,25 +187,26 @@ function output_search($guild_name = '', $guild_id = '') {
 
     // search type selection
     echo 'Search by: '
-        .'<input type="radio" onclick="name_id_check()" id="nameradio" name="typeRadio"> Name '
-        .'<input type="radio" onclick="name_id_check()" id="idradio" name="typeRadio"> ID'
+        ."<input type='radio' onclick='name_id_check()' id='nameradio' name='typeRadio' $name_checked> Name "
+        ."<input type='radio' onclick='name_id_check()' id='idradio' name='typeRadio' $id_checked> ID"
         .'<br>';
     
     // name form
-    echo '<div id="nameform" style="display:none"><br>
-              <form method="get">
-                  Name: <input type="text" name="name" value="'.htmlspecialchars($guild_name).'">
-                        <input type="submit" value="Search">
+    $html_guild_name = htmlspecialchars($guild_name);
+    echo "<div id='nameform' style='display:$name_display'><br>
+              <form method='get'>
+                  Name: <input type='text' name='name' value='$html_guild_name'>
+                        <input type='submit' value='Search'>
               </form>
-          </div>';
+          </div>";
           
     // id form
-    echo '<div id="idform" style="display:none"><br>
-              <form method="get">
-                  ID: <input type="text" name="id" oninput="this.value = this.value.replace(/[^0-9.]/g, \'\').replace(/(\..*)\./g, \'$1\');" value="'.$guild_id.'">
-                      <input type="submit" value="Search">
+    echo "<div id='idform' style='display:$id_display'><br>
+              <form method='get'>
+                  ID: <input type='text' name='id' oninput=\"this.value = this.value.replace(/[^0-9.]/g, \'\').replace(/(\..*)\./g, \'$1\');\" value='$guild_id'>
+                      <input type='submit' value='Search'>
               </form>
-          </div>';
+          </div>";
     
     // end center
     echo '</center>';

--- a/http_server/www/leaderboard.php
+++ b/http_server/www/leaderboard.php
@@ -4,8 +4,8 @@ require_once __DIR__ . '/../fns/all_fns.php';
 require_once __DIR__ . '/../fns/output_fns.php';
 require_once __DIR__ . '/../queries/users/users_select_top.php';
 
-$start = (int) default_val($_GET['start'], 0);
-$count = (int) default_val($_GET['count'], 100);
+$start = (int) default_get('start', 0);
+$count = (int) default_get('count', 100);
 $group_colors = ["7e7f7f", "047b7b", "1c369f", "870a6f"];
 $ip = get_ip();
 
@@ -59,9 +59,7 @@ try {
         $group_color = $group_colors[$group];
 
         // rank
-        $pr2_rank = (int) $user->rank;
-        $used_tokens = (int) $user->used_tokens;
-        $active_rank = $pr2_rank + $used_tokens;
+        $active_rank = (int) $user->active_rank;
 
         // hats
         $hat_array = $user->hats;


### PR DESCRIPTION
**Guild Search:**

This seemed to work on my localhost. It will hopefully have the same result here!

**Leaderboard:**

While debugging, I noticed that `users_select_top` was requiring `GROUP BY` to be present with the aggregate function `SUM()`.  When I grouped by `name`, it told me `pr2.rank` needed to be included since it was in the `SUM()` function.  It subsequently continued to tell me I needed more columns until I ended up with the monstrosity that is line 14.  From there, it seems to work okay in my test database, although I'm not sure if that's an effective method of fixing the problem. :thinking:

An alternative fix is to disable `ONLY_FULL_GROUP_BY` in the database to get rid of the `GROUP BY` line (14).  More info here: https://stackoverflow.com/questions/23921117/disable-only-full-group-by