### PR TITLE
Add /unkick for accidental kicks

### DIFF
--- a/multiplayer_server/LocalBans.php
+++ b/multiplayer_server/LocalBans.php
@@ -16,6 +16,21 @@ class LocalBans
     }
     
     
+    public static function remove($user_name)
+    {
+        $len = count(self::$arr);
+        for ($i=0; $i<$len; $i++) {
+            $ban = self::$arr[$i];
+            if ($ban->user_name == $user_name) {
+                array_splice(self::$arr, $i, 1);
+                return true;
+            }
+            continue;
+        }
+        return false;
+    }
+    
+    
     public static function is_banned($user_name)
     {
         $match = false;

--- a/multiplayer_server/Player.php
+++ b/multiplayer_server/Player.php
@@ -665,7 +665,7 @@ class Player
                 } else {
                     if ($this->group >= 2) {
                         if ($this->temp_mod === false) {
-                            $mod = '<br>Moderator:<br>- /a (Announcement)<br>- /give *text*<br>- /kick *name*<br>- /disconnect *name*<br>- /clear';
+                            $mod = '<br>Moderator:<br>- /a (Announcement)<br>- /give *text*<br>- /kick *name*<br>- /unkick *name*<br>- /disconnect *name*<br>- /clear';
                             $effects = '<br>Chat Effects:<br>- /b (Bold)<br>- /i (Italics)<br>- /u (Underlined)<br>- /li (Bulleted)';
                         }
                         if ($this->group >= 3 && $this->server_owner == false) {

--- a/multiplayer_server/Player.php
+++ b/multiplayer_server/Player.php
@@ -535,6 +535,10 @@ class Player
             elseif (strpos($chat_message, '/kick ') === 0 && $this->group >= 2 && ($this->temp_mod === false || $this->server_owner == true)) {
                 $kicked_name = trim(substr($chat_message, 6));
                 client_kick($this->socket, $kicked_name);
+            } // unkick command
+            elseif (strpos($chat_message, '/unkick ') === 0 && $this->group >= 2 && ($this->temp_mod === false || $this->server_owner == true)) {
+                $unkicked_name = trim(substr($chat_message, 8));
+                client_unkick($this->socket, $unkicked_name);
             } // disconnect command
             elseif ((strpos($chat_message, '/dc ') === 0 || strpos($chat_message, '/disconnect ') === 0) && $this->group >= 2 && ($this->temp_mod === false || $this->server_owner == true)) {
                 $dc_name = trim(substr($chat_message, 12)); // for /disconnect

--- a/multiplayer_server/client/moderation.php
+++ b/multiplayer_server/client/moderation.php
@@ -53,6 +53,34 @@ function client_kick($socket, $data)
 }
 
 
+//--- unkick a player -------------------------------------------------------------
+function client_unkick($socket, $data)
+{
+    global $pdo, $guild_id, $server_name;
+    $name = $data;
+
+    // get some info
+    $mod = $socket->get_player();
+    $unkicked_name = htmlspecialchars($name);
+
+    // if the player actually has the power to do what they're trying to do, then do it
+    if (($mod->group >= 2 && $mod->temp_mod === false) || $mod->server_owner === true) {
+        LocalBans::remove($name);
+        
+        // unkick them, yo
+        $mod->write("message`$unkicked_name has been unkicked! Hooray for second chances!");
+
+        // log the action if it's on a public server
+        if ((int) $guild_id === 0) {
+            $mod_name = $mod->name;
+            $mod_ip = $mod->ip;
+            $mod_id = $mod->user_id;
+            mod_action_insert($pdo, $mod_id, "$mod_name unkicked $name from $server_name from $mod_ip.", $mod_id, $mod_ip);
+        }
+    }
+}
+
+
 //--- warn a player -------------------------------------------------------------
 function client_warn($socket, $data)
 {

--- a/multiplayer_server/fns/demod.php
+++ b/multiplayer_server/fns/demod.php
@@ -1,5 +1,6 @@
 <?php
 
+require_once __DIR__ . '/../../http_server/queries/users/name_to_id.php';
 require_once __DIR__ . '/../../http_server/queries/users/user_select.php';
 require_once __DIR__ . '/../../http_server/queries/users/user_update_power.php';
 require_once __DIR__ . '/../../http_server/queries/mod_powers/mod_power_delete.php';
@@ -27,8 +28,8 @@ function demote_mod($user_name, $admin, $demoted_player)
     }
 
     // let the server owner demote temps
-    if ($admin->server_owner == true) {
-        if (isset($demoted_player) && $demoted_player->temp_mod == true) {
+    if ($admin->server_owner === true) {
+        if (isset($demoted_player) && $demoted_player->temp_mod === true) {
             $demoted_player->group = 1;
             $demoted_player->write('setGroup`1');
             $demoted_player->temp_mod = false;
@@ -41,8 +42,13 @@ function demote_mod($user_name, $admin, $demoted_player)
     }
 
     try {
-        $user_id = $demoted_player->user_id;
+        // get user ids
         $admin_id = $admin->user_id;
+        if (isset($demoted_player)) {
+            $user_id = $demoted_player->user_id;
+        } else {
+            $user_id = name_to_id($pdo, $user_name);
+        }
 
         // check for proper permission in the db (3rd + final line of defense before promotion)
         $admin_row = user_select($pdo, $admin_id);

--- a/multiplayer_server/fns/demod.php
+++ b/multiplayer_server/fns/demod.php
@@ -1,7 +1,7 @@
 <?php
 
-require_once __DIR__ . '/../../http_server/queries/users/name_to_id.php';
 require_once __DIR__ . '/../../http_server/queries/users/user_select.php';
+require_once __DIR__ . '/../../http_server/queries/users/user_select_by_name.php';
 require_once __DIR__ . '/../../http_server/queries/users/user_update_power.php';
 require_once __DIR__ . '/../../http_server/queries/mod_powers/mod_power_delete.php';
 require_once __DIR__ . '/../../http_server/queries/staff/actions/admin_action_insert.php';
@@ -44,22 +44,20 @@ function demote_mod($user_name, $admin, $demoted_player)
     try {
         // get user ids
         $admin_id = $admin->user_id;
-        if (isset($demoted_player)) {
-            $user_id = $demoted_player->user_id;
-        } else {
-            $user_id = name_to_id($pdo, $user_name);
-        }
 
         // check for proper permission in the db (3rd + final line of defense before promotion)
         $admin_row = user_select($pdo, $admin_id);
         if ($admin_row->power != 3) {
-            throw new Exception("You lack the power to demote $user_name.");
+            throw new Exception("You lack the power to demote $html_user_name.");
         }
 
-        // check if the person being demoted is a staff member
-        $user_row = user_select($pdo, $user_id);
+        // get user info
+        $user_row = user_select_by_name($pdo, $user_name);
+        $user_id = (int) $user_row->user_id;
+        
+        // check if the person being demoted is an admin
         if ((int) $user_row->power === 3) {
-            throw new Exception("You lack the power to demote $user_name, as they are an admin.");
+            throw new Exception("You lack the power to demote $html_user_name, as they are an admin.");
         }
 
         // delete mod entry


### PR DESCRIPTION
Currently, the only way to get rid of an accidental kick is to restart the entire server. This pull enables trial/permanent mods and server owners (no temps) to remove accidental kicks using the /unkick command.

Edit: This pull also includes a fix for admins trying to demote offline users displaying "Error: Could not find a user with that ID."