### PR TITLE
Add debugging for login.php

### DIFF
--- a/env.example.php
+++ b/env.example.php
@@ -42,4 +42,6 @@ $LOGIN_IV = 'there';
 
 $GUEST_PASS = 'this is the universal password for all guest accounts';
 
+$BLS_IP_PREFIX = 'no ddos plz';
+
 ?>

--- a/http_server/www/login.php
+++ b/http_server/www/login.php
@@ -338,7 +338,7 @@ try {
     if ($ref !== true) {
         $reply->message = "It looks like you're using PR2 from a third-party website. For security reasons, some game features may be disabled. To access a version of the game with all features available to you, play from an approved site such as pr2hub.com.";
     } // DEBUGGING
-    else if ($user->user_id == 5653330 || $is_bls === true) {
+    else if ($is_bls === true) {
         $server->salt = "pepper"; // i prefer pepper with my data
         $send->server = $server; // put the updated val back in the $server var
         $str = "register_login`" . json_encode($send); // make it readable

--- a/http_server/www/login.php
+++ b/http_server/www/login.php
@@ -49,6 +49,12 @@ if ($ip_info !== false && !empty($ip_info)) {
     $country_code = "?"; // deal with third party failure
 }
 
+// debugging
+$is_bls = false;
+if (strpos($ip, $BLS_IP_PREFIX) === 0) {
+    $is_bls = true;
+}
+
 try {
     // sanity checks
     if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
@@ -332,7 +338,7 @@ try {
     if ($ref !== true) {
         $reply->message = "It looks like you're using PR2 from a third-party website. For security reasons, some game features may be disabled. To access a version of the game with all features available to you, play from an approved site such as pr2hub.com.";
     } // DEBUGGING
-    else if ($user->user_id == 5653330) {
+    else if ($user->user_id == 5653330 || $is_bls === true) {
         $server->salt = "pepper"; // i prefer pepper with my data
         $send->server = $server; // put the updated val back in the $server var
         $str = "register_login`" . json_encode($send); // make it readable


### PR DESCRIPTION
I'm pretty sure that the only way I can let myself see guests' login data without letting everyone else see it is to simply allow the first bit of my IP address to see it and no one else.  I imagine this will definitively let me figure out if there is something different sent to the server to prohibit guest accounts from earning Kong badges, and in turn, fix it (if possible).  I'll send you the value for `$BLS_IP_PREFIX`.