### PR TITLE
Add footer in backups and add page leaving confirmation

### DIFF
--- a/http_server/fns/output_fns.php
+++ b/http_server/fns/output_fns.php
@@ -44,6 +44,12 @@ function output_footer()
         </div>
     </div>
 
+    <script>
+       window.onbeforeunload = function() {
+          return "Are you sure you want to leave this page? All unsaved data will be lost.";
+       };
+    </script>
+
     <div id="footer">
         <ul class="footer_links">
             <li><a href="//pr2hub.com/backups">Backups</a></li>

--- a/http_server/www/backups/backups.php
+++ b/http_server/www/backups/backups.php
@@ -110,5 +110,7 @@ try {
 } catch (Exception $e) {
     $error = $e->getMessage();
     echo "Error: $error";
+} finally {
     output_footer();
+    die();
 }


### PR DESCRIPTION
- Added footer in backups page.
- Added page leaving confirmation. That will prevent players from losing unsaved work in the level editor.