### PR TITLE
Simplify is_from_game()

### DIFF
--- a/http_server/www/logout.php
+++ b/http_server/www/logout.php
@@ -29,7 +29,7 @@ try {
     rate_limit('logout-'.$ip, 60, 10, 'Only 10 logout requests per minute per IP are accepted.');
 
     if (is_from_game() !== true){
-     throw new Exception("For security reasons logout can only be performed from game");   
+     throw new Exception("It looks like you're not using PR2 to log out. For security reasons, you may only log out from a PR2 client.");   
     }
     
     if (isset($_COOKIE['token'])) {

--- a/http_server/www/logout.php
+++ b/http_server/www/logout.php
@@ -5,25 +5,6 @@ require_once __DIR__ . '/../queries/tokens/token_delete.php';
 
 header("Content-type: text/plain");
 
-function is_from_game(){
- if (isset($_SERVER["HTTP_X_REQUESTED_WITH"]) && !empty($_SERVER["HTTP_X_REQUESTED_WITH"])){
-  if (!isset($_SERVER["HTTP_REFERER"]) || $_SERVER["HTTP_REFERER"] === ""){
-   return true;
-  }
-  if (strpos($_SERVER["HTTP_X_REQUESTED_WITH"], "ShockwaveFlash/") !== 0){
-   return true;
-  }
-     else
-  {
-      return false;   
-  }
- }
- else
- {
-    return false;
- }
-}
-
 $ip = get_ip();
 
 try {
@@ -50,4 +31,17 @@ try {
 } catch (Exception $e) {
     $error = $e->getMessage();
     echo "error=$error";
+}
+
+function is_from_game() 
+{
+    $is_from_game = false;
+    
+    if ((!is_empty($_SERVER["HTTP_X_REQUESTED_WITH"]) &&
+        strpos($_SERVER["HTTP_X_REQUESTED_WITH"], "ShockwaveFlash/") !== 0) ||
+        is_empty($_SERVER["HTTP_REFERER"])) {
+        $is_from_game = true;
+    }
+    
+    return $is_from_game;
 }

--- a/http_server/www/logout.php
+++ b/http_server/www/logout.php
@@ -37,10 +37,14 @@ function is_from_game()
 {
     $is_from_game = false;
     
-    if ((!is_empty($_SERVER["HTTP_X_REQUESTED_WITH"]) &&
-        strpos($_SERVER["HTTP_X_REQUESTED_WITH"], "ShockwaveFlash/") !== 0) ||
-        is_empty($_SERVER["HTTP_REFERER"])) {
-        $is_from_game = true;
+    if (
+           (
+           !is_empty($_SERVER["HTTP_X_REQUESTED_WITH"]) &&
+           strpos($_SERVER["HTTP_X_REQUESTED_WITH"], "ShockwaveFlash/") !== 0
+           ) ||
+       is_empty($_SERVER["HTTP_REFERER"])
+    ) {
+         $is_from_game = true;
     }
     
     return $is_from_game;

--- a/http_server/www/logout.php
+++ b/http_server/www/logout.php
@@ -7,6 +7,9 @@ header("Content-type: text/plain");
 
 function is_from_game(){
  if (isset($_SERVER["HTTP_X_REQUESTED_WITH"]) && !empty($_SERVER["HTTP_X_REQUESTED_WITH"])){
+  if (!isset($_SERVER["HTTP_REFERER"]) || $_SERVER["HTTP_REFERER"] === ""){
+   return true;
+  }
   if (strpos($_SERVER["HTTP_X_REQUESTED_WITH"], "ShockwaveFlash/") !== 0){
    return true;
   }

--- a/http_server/www/logout.php
+++ b/http_server/www/logout.php
@@ -5,6 +5,22 @@ require_once __DIR__ . '/../queries/tokens/token_delete.php';
 
 header("Content-type: text/plain");
 
+function is_from_game(){
+ if (isset($_SERVER["HTTP_X_REQUESTED_WITH"]) && !empty($_SERVER["HTTP_X_REQUESTED_WITH"])){
+  if (strpos($_SERVER["HTTP_X_REQUESTED_WITH"], "ShockwaveFlash/") !== 0){
+   return true;
+  }
+     else
+  {
+      return false;   
+  }
+ }
+ else
+ {
+    return false;
+ }
+}
+
 $ip = get_ip();
 
 try {
@@ -12,6 +28,10 @@ try {
     rate_limit('logout-'.$ip, 5, 2, 'Please wait at least 5 seconds before attempting to log out again.');
     rate_limit('logout-'.$ip, 60, 10, 'Only 10 logout requests per minute per IP are accepted.');
 
+    if (is_from_game() !== true){
+     throw new Exception("For security reasons logout can only be performed from game");   
+    }
+    
     if (isset($_COOKIE['token'])) {
         // connect to the db
         $pdo = pdo_connect();


### PR DESCRIPTION
There's really no way to avoid this monstrosity of a line while keeping PSR-2 compliance without breaking it into a few lines.  Additionally, doing it all in one if statement is more efficient when both versions of the code would put the lines over 80 characters per line anyway.

Also, removed some unnecessary if/else blocks and consolidated our return boolean into one variable.