### PR TITLE
Fix tournament win times

### DIFF
--- a/multiplayer_server/rooms/Game.php
+++ b/multiplayer_server/rooms/Game.php
@@ -424,9 +424,9 @@ class Game extends Room
     }
 
     
-    private function ensure_time_format($time) {
+    private function timeFormat($time, $digits = 2) {
         if ($time < 0) $time = 0;
-        return round($time, 2);
+        return round($time, $digits);
     }
     
 
@@ -435,7 +435,12 @@ class Game extends Room
         global $pdo;
 
         if ($player->finished_race === false && !isset($player->race_stats->finish_time) && $player->race_stats->drawing === false && $this->begun === true) {
-            $finish_time = $this->ensure_time_format(microtime(true) - $this->start_time);
+            $finish_microtime = microtime(true);
+            $full_time = $finish_microtime - $this->start_time;
+            
+            // get/format/validate/set finish time
+            $finish_time = $this->timeFormat($full_time);
+            $broadcast_time = $this->timeFormat($full_time, 3);
             if ($finish_time > 31536000) {
                 $finish_time = 0; // if the race time > 1 year, set it to 0
             }
@@ -450,7 +455,7 @@ class Game extends Room
 
             // announce on tournament server
             if ($place == 0 && count($this->finish_array) > 1 && $finish_time > 10 && pr2_server::$tournament) {
-                $this->broadcast_results($player, $finish_time);
+                $this->broadcast_results($player, $broadcast_time);
             }
 
             //--- prize -----------


### PR DESCRIPTION
Fixes the issue where the third decimal digit always displays as zero on scores being broadcasted to main with tournament mode on.

This should be fairly easy to move to lint, once ready.