### PR TITLE
Check if guild exists before attempting to create

### DIFF
--- a/http_server/queries/guilds/guild_name_to_id.php
+++ b/http_server/queries/guilds/guild_name_to_id.php
@@ -1,6 +1,6 @@
 <?php
 
-function guild_name_to_id($pdo, $guild_name)
+function guild_name_to_id($pdo, $guild_name, $suppress_error = false)
 {
     $stmt = $pdo->prepare('
         SELECT guild_id
@@ -18,7 +18,11 @@ function guild_name_to_id($pdo, $guild_name)
     $guild = $stmt->fetch(PDO::FETCH_OBJ);
     
     if (empty($guild)) {
-        throw new Exception('Could not find a guild with that name.');
+        if ($suppress_error === false) {
+            throw new Exception('Could not find a guild with that name.');
+        } else {
+            return false;
+        }
     }
     
     return $guild->guild_id;

--- a/http_server/www/guild_create.php
+++ b/http_server/www/guild_create.php
@@ -4,6 +4,7 @@ header("Content-type: text/plain");
 require_once __DIR__ . '/../fns/all_fns.php';
 require_once __DIR__ . '/../queries/users/user_select_expanded.php';
 require_once __DIR__ . '/../queries/users/user_update_guild.php';
+require_once __DIR__ . '/../queries/guilds/guild_name_to_id.php';
 require_once __DIR__ . '/../queries/guilds/guild_insert.php';
 
 $note = filter_swears(find('note'));
@@ -60,6 +61,12 @@ try {
     }
     if (strlen(trim($guild_name)) === 0) {
         throw new Exception('I\'m not sure what would happen if you didn\'t enter a guild name, but it would probably destroy the world.');
+    }
+    
+    // check if guild exists
+    $guild_exists = guild_name_to_id($pdo, $guild_name, true);
+    if ($guild_exists !== false) {
+        throw new Exception('A guild with this name already exists. Please choose a new name.');
     }
 
     // more rate limiting


### PR DESCRIPTION
Right now, if you attempt to create a guild and it exists, you can't try again for another hour due to how the rate limiting is set up.  This pull checks if a guild name exists before adding to the rate limit and attempting to create a new guild, thereby fixing the issue.