### PR TITLE
Change "!==" to "==="

### DIFF
--- a/http_server/fns/data_fns.php
+++ b/http_server/fns/data_fns.php
@@ -4,9 +4,10 @@
 function is_from_game()
 {
     $req_with = default_server("HTTP_X_REQUESTED_WITH");
+    $referer = default_server("HTTP_REFERER");
     $is_from_game = false;
 
-    if (!empty($req_with) && strpos($req_with, "ShockwaveFlash/") === 0) {
+    if (!empty($req_with) && strpos($req_with, "ShockwaveFlash/") === 0 || !isset($referer)) {
          $is_from_game = true;
     }
 

--- a/http_server/fns/data_fns.php
+++ b/http_server/fns/data_fns.php
@@ -4,13 +4,11 @@
 function is_from_game()
 {
     $req_with = default_server("HTTP_X_REQUESTED_WITH");
-    $referer = default_server("HTTP_REFERER");
+    $ref = default_server("HTTP_REFERER");
     
-    $allowedurls = array("http://pr2hub.com/", "https://pr2hub.com/", "https://jiggmin2.com/games/platform-racing-2/", "https://www.kongregate.com/");
-    
+    // is it from the game?
     $is_from_game = false;
-
-    if (!empty($req_with) && strpos($req_with, "ShockwaveFlash/") === 0 || !isset($referer) || is_empty($referer) || in_array($referer, $allowedurls) === true) {
+    if ((!empty($req_with) && strpos($req_with, "ShockwaveFlash/") === 0) || is_empty($ref)) {
          $is_from_game = true;
     }
 

--- a/http_server/fns/data_fns.php
+++ b/http_server/fns/data_fns.php
@@ -3,16 +3,16 @@
 // requests from a flash client will include this header
 function is_from_game()
 {
-    $req_with = default_server("HTTP_X_REQUESTED_WITH");
+    $req_with = default_server("HTTP_X_REQUESTED_WITH", "");
     $ref = default_server("HTTP_REFERER");
     
-    // is it from the game?
-    $is_from_game = false;
-    if ((!empty($req_with) && strpos($req_with, "ShockwaveFlash/") === 0) || is_empty($ref)) {
-         $is_from_game = true;
+    // let people type in the url manually
+    if (is_empty($ref)) {
+        return true;
     }
-
-    return $is_from_game;
+    
+    // does the request originate from the flash player?
+    return strpos($req_with, "ShockwaveFlash/") === 0
 }
 
 // check if player has an epic color option for a part

--- a/http_server/fns/data_fns.php
+++ b/http_server/fns/data_fns.php
@@ -5,9 +5,12 @@ function is_from_game()
 {
     $req_with = default_server("HTTP_X_REQUESTED_WITH");
     $referer = default_server("HTTP_REFERER");
+    
+    $allowedurls = array("http://pr2hub.com/", "https://pr2hub.com/", "https://jiggmin2.com/games/platform-racing-2/", "https://www.kongregate.com/");
+    
     $is_from_game = false;
 
-    if (!empty($req_with) && strpos($req_with, "ShockwaveFlash/") === 0 || !isset($referer)) {
+    if (!empty($req_with) && strpos($req_with, "ShockwaveFlash/") === 0 || !isset($referer) || is_empty($referer) || in_array($referer, $allowedurls) === true) {
          $is_from_game = true;
     }
 

--- a/http_server/fns/data_fns.php
+++ b/http_server/fns/data_fns.php
@@ -4,10 +4,9 @@
 function is_from_game()
 {
     $req_with = default_server("HTTP_X_REQUESTED_WITH");
-    $ref = default_server("HTTP_REFERER");
     $is_from_game = false;
 
-    if ((!is_empty($req_with) && strpos($req_with, "ShockwaveFlash/") !== 0) || is_empty($ref)) {
+    if (!empty($req_with) && strpos($req_with, "ShockwaveFlash/") === 0) {
          $is_from_game = true;
     }
 

--- a/http_server/www/logout.php
+++ b/http_server/www/logout.php
@@ -12,6 +12,13 @@ try {
     rate_limit('logout-'.$ip, 5, 2, 'Please wait at least 5 seconds before attempting to log out again.');
     rate_limit('logout-'.$ip, 60, 10, 'Only 10 logout requests per minute per IP are accepted.');
 
+    if (is_from_game() !== true) {
+        throw new Exception(
+            "It looks like you're not using PR2 to log out.	"
+            ."For security reasons, you may only log out from a PR2 client."
+        );
+    }
+
     if (isset($_COOKIE['token'])) {
         // connect to the db
         $pdo = pdo_connect();


### PR DESCRIPTION
Changed "!==" on strpos to "===" to correctly check is "ShockwaveFlash/" in the X-Requested-With header because "!==" was checking if it's not in string so this should fix the error when using this on logout.
Referer check wasn't needed there because it doesn't really have an use on this case.