### PR TITLE
Allow admins to restart all servers at once

### DIFF
--- a/http_server/www/admin/restart_servers.php
+++ b/http_server/www/admin/restart_servers.php
@@ -1,0 +1,92 @@
+<?php
+
+require_once __DIR__ . '/../../fns/all_fns.php';
+require_once __DIR__ . '/../../fns/output_fns.php';
+require_once __DIR__ . '/../../fns/shell_output_fns.php';
+require_once __DIR__ . '/../../queries/servers/servers_select.php';
+require_once __DIR__ . '/../../queries/staff/actions/admin_action_insert.php';
+
+$ip = get_ip();
+$action = find('action', 'warning');
+$token = $_POST['token'];
+
+try {
+    // rate limiting
+    rate_limit('restart-servers-'.$ip, 30, 5);
+    rate_limit('restart-servers-'.$ip, 5, 1);
+
+    // connect
+    $pdo = pdo_connect();
+    
+    // check permission
+    $admin = 3483035; //check_moderator($pdo, false, 3);
+} catch (Exception $e) {
+    output_header('Error');
+    echo "Error: " . $e->getMessage();
+    output_footer();
+    die();
+}
+
+try {
+    // output header
+    output_header('Restart Servers', true, true);
+    
+    if ($action == 'warning') {
+        echo "WARNING: Continuing will restart every PR2 server. "
+            ."If you choose to proceed, this action will disconnect EVERY player currently online on every server. "
+            ."Are you SURE you want to disconnect all players and restart all PR2 servers?<br><br>";
+        echo '<form method="post">'
+            .'<input type="hidden" name="action" value="restart">'
+            .'<input type="hidden" name="token" value="'.$_COOKIE['token'].'">'
+            .'<input type="submit" value="Yes, RESTART ALL PR2 SERVERS">&nbsp;(no confirmation!)'
+            .'</form>';
+        output_footer();
+        die();
+    } elseif ($action == 'restart') {
+        // referrer check
+        require_trusted_ref('', true);
+        
+        // make sure the token exists and is valid for this admin
+        $auth = token_select($pdo, $token);
+        if ($auth->user_id != $admin->user_id) {
+            throw new Exception('Could not validate token.');
+        }
+    
+        // only let the servers be restarted with this method once per hour
+        rate_limit(
+            'do-restart-servers',
+            3600,
+            1,
+            'Please wait at least one hour before attempting to restart all active servers again.'
+        );
+        
+        // get servers
+        $servers = servers_select($pdo);
+        
+        // test all active servers at this address
+        foreach ($servers as $server) {
+            echo "Shutting down $server->server_name ($server->server_id)...<br>";
+            try {
+                $reply = talk_to_server($server->address, $server->port, $server->salt, 'shut_down`', true);
+                echo "Server Reply: $reply";
+            } catch (Exception $e) {
+                echo $e->getMessage();
+            } finally {
+                echo '<br><br>';
+            }
+        }
+
+        // record action
+        $admin_id = $admin->user_id;
+        $admin_name = $admin->name;
+        admin_action_insert($pdo, $admin_id, "$admin_name restarted ALL ACTIVE PR2 SERVERS from $ip.", $admin_id, $ip);
+        
+        // tell the world
+        echo '<span style="color: green;">All operations completed.</span>';
+    }
+} catch (Exception $e) {
+    echo 'Error: ' . $e->getMessage();
+} finally {
+    output_footer();
+    die();
+}

--- a/http_server/www/admin/restart_servers.php
+++ b/http_server/www/admin/restart_servers.php
@@ -19,7 +19,7 @@ try {
     $pdo = pdo_connect();
     
     // check permission
-    $admin = 3483035; //check_moderator($pdo, false, 3);
+    $admin = check_moderator($pdo, false, 3);
 } catch (Exception $e) {
     output_header('Error');
     echo "Error: " . $e->getMessage();


### PR DESCRIPTION
Just in case.  We can already restart individual servers, so if we need to restart all of them, we can just use this script once per hour instead of typing the command in every server one-by-one.  Extra security by passing the token via POST instead of reading it in the cookie.