### PR TITLE
Remove the old sitelock

### DIFF
--- a/http_server/www/login.php
+++ b/http_server/www/login.php
@@ -81,7 +81,6 @@ try {
     $server_id = $login->server->server_id;
     $server_port = $login->server->port;
     $server_address = $login->server->address;
-    $origination_domain = $login->domain;
     $remember = $login->remember;
     $login_code = $login->login_code;
 

--- a/http_server/www/login.php
+++ b/http_server/www/login.php
@@ -94,9 +94,6 @@ try {
             $version2
         );
     }
-    if ($origination_domain == 'local') {
-        throw new Exception('Testing mode has been disabled.');
-    }
     if ((is_empty($in_token) === true && is_empty($user_name) === true) || strpos($user_name, '`') !== false) {
         throw new Exception('Invalid user name entered.');
     }


### PR DESCRIPTION
Since we can use the `require_trusted_ref` function, the old sitelock is useless, which can be bypassed anyway.