### PR TITLE
Add various rank/exp sanity checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ To submit new ideas, post a thread in the [PR2 Suggestions](https://jiggmin2.com
 - BrokenBulb78
 - Dex472
 - EternalUF
+- famelegend1
 - fourst4r
 - Grovbi
 - isokissa3

--- a/http_server/www/login.php
+++ b/http_server/www/login.php
@@ -186,6 +186,12 @@ try {
     if ($rt_available < $rt_used) {
         $rt_used = $rt_available;
     }
+    
+    // sanity check: is the user's rank 100+?
+    $rank = (int) $stats->rank;
+    if ($rank + $rt_used >= 100) {
+        throw new Exception('Your rank is too high. Please choose a different account.');
+    }
 
     // record moderator login
     $server_name = $server->server_name;

--- a/multiplayer_server/CourseBox.php
+++ b/multiplayer_server/CourseBox.php
@@ -124,10 +124,18 @@ class CourseBox
         $course_id = substr($this->course_id, 0, strpos($this->course_id, '_'));
         $game = new Game($course_id);
         foreach ($this->slot_array as $player) {
-            $player->confirmed = false;
-            $game->addPlayer($player);
-            client_set_right_room($player->socket, 'none');
-            client_set_chat_room($player->socket, 'none');
+            if ($player->active_rank < 100 || $player->user_id == $player::FRED) {
+                $player->confirmed = false;
+                $game->addPlayer($player);
+                client_set_right_room($player->socket, 'none');
+                client_set_chat_room($player->socket, 'none');
+            } else {
+                $slot = $player->slot; // get slot
+                $player->write('message`Some data was incorrect. Please log in again.');
+                $player->remove(); // disconnect them
+                $this->slot_array[$slot] = null; // clear that slot
+                unset($this->slot_array[$slot]); // ^
+            }
         }
         $game->init();
         $this->remove();

--- a/multiplayer_server/CourseBox.php
+++ b/multiplayer_server/CourseBox.php
@@ -124,7 +124,7 @@ class CourseBox
         $course_id = substr($this->course_id, 0, strpos($this->course_id, '_'));
         $game = new Game($course_id);
         foreach ($this->slot_array as $player) {
-            if ($player->active_rank < 100 || $player->user_id == $player::FRED) {
+            if ($player->active_rank < 100 || $player->user_id === $player::FRED) {
                 $player->confirmed = false;
                 $game->addPlayer($player);
                 client_set_right_room($player->socket, 'none');

--- a/multiplayer_server/Player.php
+++ b/multiplayer_server/Player.php
@@ -1298,16 +1298,16 @@ class Player
         }
 
         // make sure none of the part values are blank to avoid server crashes
-        if (is_empty($this->hat, false)) {
+        if (empty($this->hat)) {
             $this->gainPart('hat', 1, true);
         }
-        if (is_empty($this->head, false)) {
+        if (empty($this->head)) {
             $this->gainPart('head', 1, true);
         }
-        if (is_empty($this->body, false)) {
+        if (empty($this->body)) {
             $this->gainPart('body', 1, true);
         }
-        if (is_empty($this->feet, false)) {
+        if (empty($this->feet)) {
             $this->gainPart('feet', 1, true);
         }
 

--- a/multiplayer_server/Player.php
+++ b/multiplayer_server/Player.php
@@ -1297,18 +1297,36 @@ class Player
             return false;
         }
 
+        // ensure no part arrays contain empty values
+        if (($arr_key = array_search('', $this->hat_array)) !== false) {
+            unset($this->hat_array[$arr_key]);
+        }
+        if (($arr_key = array_search('', $this->head_array)) !== false) {
+            unset($this->head_array[$arr_key]);
+        }
+        if (($arr_key = array_search('', $this->body_array)) !== false) {
+            unset($this->body_array[$arr_key]);
+        }
+        if (($arr_key = array_search('', $this->feet_array)) !== false) {
+            unset($this->feet_array[$arr_key]);
+        }
+
         // make sure none of the part values are blank to avoid server crashes
         if (empty($this->hat)) {
             $this->gainPart('hat', 1, true);
+            $this->setPart('hat', 1);
         }
         if (empty($this->head)) {
             $this->gainPart('head', 1, true);
+            $this->setPart('head', 1);
         }
         if (empty($this->body)) {
             $this->gainPart('body', 1, true);
+            $this->setPart('body', 1);
         }
         if (empty($this->feet)) {
             $this->gainPart('feet', 1, true);
+            $this->setPart('feet', 1);
         }
 
         // auto removing some hat?

--- a/multiplayer_server/Player.php
+++ b/multiplayer_server/Player.php
@@ -158,17 +158,20 @@ class Player
         global $player_array;
         global $max_players;
 
+        // check if the server is full
         if ((count($player_array) > $max_players && $this->group < 2) ||
             (count($player_array) > ($max_players-10) && $this->group == 0)
         ) {
             $this->write('loginFailure`');
             $this->write('message`Sorry, this server is full. Try back later.');
             $this->remove();
-        } elseif ($this->active_rank > 100 && $this->user_id !== self::FRED) {
+        } // check for a valid rank
+        elseif ($this->active_rank > 100 && $this->user_id !== self::FRED) {
             $this->write('loginFailure`');
             $this->write('message`Your rank is too high. Please choose a different account.');
             $this->remove();
-        } else {
+        } // add to the player array
+        else {
             $player_array[$this->user_id] = $this;
         }
 

--- a/multiplayer_server/fns/data_fns.php
+++ b/multiplayer_server/fns/data_fns.php
@@ -28,39 +28,6 @@ function find_variable($string, $default)
 
 
 
-//--- tests if a value is empty using a variety of functions --------------------------------
-function is_empty($str, $incl_zero = true)
-{
-    /*
-    $incl_zero: checks if the user wants to include the string "0" in the empty check.
-    If not, empty($str) will make this function return true.
-    */
-
-    // if the string length is 0, it's empty
-    if (strlen(trim($str)) === 0) {
-        return true;
-    }
-    // if the string isn't set, it's empty
-    if (!isset($str)) {
-        return true;
-    }
-    // if the string is empty and not 0, it's empty
-    if ($incl_zero) {
-        if (empty($str) && $str != '0') {
-            return true;
-        }
-    } // if the string is empty, it's empty
-    else {
-        if (empty($str)) {
-            return true;
-        }
-    }
-    // you're still here? must mean $str isn't empty
-    return false;
-}
-
-
-
 //--- tests to see if a string contains obscene words ---------------------------------------
 function is_obscene($str)
 {


### PR DESCRIPTION
This pull includes code that @famelegend1 wrote in #453 and #455, slightly modified.  A huge thank-you to him for inspiring the changes in ab19b37. :pray:

Socket Server:
 - Check for rank 100 or above (except for Fred) on login in `Player.php`
 - Check for rank 100 or above (except for Fred) when entering a race, d/c if above rank 100
 - Check for a rank 100 or above when awarding opponent bonus EXP, and set to 0 if found
 - Fix php warnings being sent to the console when `` loginFailure` `` is sent from `Player.php` (i.e. server full, rank 100 or above check on login)
 - Fix a small bug that would crash the server if nothing was set for the hat, head, body, or feet values

HTTP Server:
 - Check for rank 100 or above on login in `login.php`

README.md:
 - Added @famelegend1