### PR TITLE
Fix random song in levels

### DIFF
--- a/http_server/www/upload_level.php
+++ b/http_server/www/upload_level.php
@@ -136,7 +136,20 @@ try {
         // update existing level
         $version = $level->version + 1;
         $level_id = $level->level_id;
-        level_update($pdo, $level_id, $title, $note, $live, $time, $ip, $min_level, (int) $song, $version, $hash2, $type);
+        level_update(
+            $pdo,
+            $level_id,
+            $title,
+            $note,
+            $live,
+            $time,
+            $ip,
+            $min_level,
+            (int) $song,
+            $version,
+            $hash2,
+            $type
+        );
     } else {
         level_insert($pdo, $title, $note, $live, $time, $ip, $min_level, (int) $song, $user_id, $hash2, $type);
         $level = level_select_by_title($pdo, $user_id, $title);

--- a/http_server/www/upload_level.php
+++ b/http_server/www/upload_level.php
@@ -136,9 +136,9 @@ try {
         // update existing level
         $version = $level->version + 1;
         $level_id = $level->level_id;
-        level_update($pdo, $level_id, $title, $note, $live, $time, $ip, $min_level, $song, $version, $hash2, $type);
+        level_update($pdo, $level_id, $title, $note, $live, $time, $ip, $min_level, (int) $song, $version, $hash2, $type);
     } else {
-        level_insert($pdo, $title, $note, $live, $time, $ip, $min_level, $song, $user_id, $hash2, $type);
+        level_insert($pdo, $title, $note, $live, $time, $ip, $min_level, (int) $song, $user_id, $hash2, $type);
         $level = level_select_by_title($pdo, $user_id, $title);
         $level_id = $level->level_id;
         $version = $level->version;


### PR DESCRIPTION
The typecast to an integer at the introduction of the `$song` variable messed up the saving of a random song, because the client interprets an empty `song=` value as a random song and `song=0` as "None".  This pull makes it so the song string (song ID; what's passed in `$_POST['song']`) is only typecast to an integer right before adding to the database.