### PR TITLE
New right click menu

### DIFF
--- a/http_server/fns/output_fns.php
+++ b/http_server/fns/output_fns.php
@@ -129,6 +129,7 @@ function output_header($title = '', $formatting_for_mods = false, $formatting_fo
     <title>PR2 Hub - <?php echo $title; ?></title>
     <link href="//pr2hub.com/style/gwibble.css" rel="stylesheet" type="text/css" />
     <link href="//pr2hub.com/style/pr2hub.css" rel="stylesheet" type="text/css"/>
+    <script src="//pr2hub.com/pr2hubmenu.js" type="text/javascript"></script>
     <?php if ($formatting_for_mods) { ?>
         <script src="https://code.jquery.com/jquery-latest.min.js"></script>
         <script src="https://malsup.github.io/jquery.form.js"></script>

--- a/http_server/www/pr2hubmenu.js
+++ b/http_server/www/pr2hubmenu.js
@@ -1,0 +1,193 @@
+    "use strict";
+	
+    var menu_css_decoded = window.atob("LmhjbGFzc3sNCglkaXNwbGF5OiBub25lOw0KfQ0KI3BybWVudXsNCgliYWNrZ3JvdW5kLWNvbG9yOiAjMDA4MEZGOw0KCWJvcmRlcjogMHB4IHNvbGlkICMwMDAwMDA7DQoJYm9yZGVyLXJhZGl1czogNXB4Ow0KCXdpZHRoOiAyNTBweDsNCgloZWlnaHQ6IDQwMHB4Ow0KCXBvc2l0aW9uOiBhYnNvbHV0ZTsNCglvdmVyZmxvdy15OiBhdXRvOw0KCWFuaW1hdGlvbjogbG9hZG1lbnUgMC41cyBzdGVwcyg2MCxlbmQpOw0KCWJveC1zaGFkb3c6IDBweCAwcHggMjBweCAjMDAwMDAwOw0KCXotaW5kZXg6IDk5OTk7DQp9DQojbWVudWhpbnR7DQoJYmFja2dyb3VuZC1jb2xvcjogIzAwODBGRjsNCglwb3NpdGlvbjogZml4ZWQ7DQoJaGVpZ2h0OiAyMHB4Ow0KCXRvcDogMHB4Ow0KCW1hcmdpbjogMHB4Ow0KCWxlZnQ6IDM1JTsNCgl3aWR0aDogNDAwcHg7DQoJb3BhY2l0eTogMC43Ow0KCXotaW5kZXg6IDk5OTk5Ow0KfQ0Kc3Bhbi5tZW51aHRleHR7DQoJZm9udC1zaXplOiAxNnB4Ow0KCWNvbG9yOiAjRkZGRkZGOw0KfQ0Kc3Bhbi5tZW51dGl0bGV7DQoJY29sb3I6ICNGQUNDMkU7DQoJZm9udC1zaXplOiAyNnB4Ow0KCWJhY2tncm91bmQtY29sb3I6ICMwMDAwMDA7DQoJZGlzcGxheTogYmxvY2s7DQp9DQpoci5tZW51ZGl2aWRlcnsNCgl3aWR0aDogNTAlOw0KfQ0KYS5tZW51bGlua3sNCgljb2xvcjogI0ZBQ0MyRTsNCglkaXNwbGF5OiBibG9jazsNCgl3b3JkLXdyYXA6IGJyZWFrLXdvcmQ7DQoJZm9udC1zaXplOiAyMnB4Ow0KfQ0KYS5tZW51bGluazpob3ZlcnsNCgliYWNrZ3JvdW5kLWNvbG9yOiAjMDAwMDAwOw0KCXRyYW5zaXRpb24tZHVyYXRpb246IDFzOw0KCS1tb3otdHJhbnNpdGlvbi1kdXJhdGlvbjogMXM7DQoJLXdlYmtpdC10cmFuc2l0aW9uLWR1cmF0aW9uOiAxczsNCglkaXNwbGF5OiBibG9jazsNCn0NCmEubWVudWxpbms6bm90KDpob3Zlcil7DQoJdHJhbnNpdGlvbi1kdXJhdGlvbjogMXM7DQoJLW1vei10cmFuc2l0aW9uLWR1cmF0aW9uOiAxczsNCgktd2Via2l0LXRyYW5zaXRpb24tZHVyYXRpb246IDFzOw0KCWRpc3BsYXk6IGJsb2NrOw0KfQ0KQGtleWZyYW1lcyBsb2FkbWVudXsNCglmcm9tew0KCQloZWlnaHQ6IDBweDsNCgkJb3BhY2l0eTogMDsNCgl9Ow0KfQ==");
+	
+	var menu_enabled = false;
+	
+	function insert_css(){
+		var menucss = document.createElement("style");
+		menucss.innerHTML = menu_css_decoded;
+		document.body.appendChild(menucss);
+	}
+	
+	function insert_menu_code(){
+		var hub_menu = document.createElement("div");
+		hub_menu.setAttribute("class", "hclass");
+		hub_menu.setAttribute("id", "prmenu");
+		document.body.appendChild(hub_menu);
+	}
+	
+	function display_menu_hint(){
+		var menu_hint = document.createElement("div");
+		menu_hint.setAttribute("id", "menuhint");
+		menu_hint.innerHTML = "<center><span class=\"menuhtext\">Press M to enable right click directory menu</span></center>";
+		document.body.appendChild(menu_hint);
+	}
+	
+	function hide_menu_hint(){
+		document.getElementById("menuhint").style.display = "none";
+	}
+	
+	function unhide_menu_hint(){
+		document.getElementById("menuhint").style.display = "block";
+	}
+	
+	function goto_ban(){
+		var ban_id = window.prompt("Enter ban id");
+		if (ban_id !== null && ban_id !== "" && isNaN(ban_id) === false){
+			location.href = "/bans/show_record.php?ban_id=" + ban_id;
+		}
+		else
+		{
+			//no value given
+		}
+	}
+	
+	function set_background(){
+		var user_bg_url = window.prompt("Enter direct link to image to use as background");
+		if (user_bg_url !== null && user_bg_url !== ""){
+			if (user_bg_url.startsWith("http://") === true || user_bg_url.startsWith("https://") === true){
+				document.body.style.cssText = "background-image: url(" + user_bg_url + "); background-attachment: fixed; background-size: cover";
+			}
+			else
+			{
+				alert("Given link doesn't seem valid");
+			}
+		}
+		else
+		{
+			//no value given
+		}
+	}
+	
+	function skip_to_page(){
+		var page_num = window.prompt("Page number on bans to skip to (pages start at 0)");
+		if (page_num !== null && page_num !== "" && isNaN(page_num) === false){
+			location.replace("/bans/bans.php?start=" + page_num * 100 + "&count=100");
+		}
+		else
+		{
+			//invalid value or no value given
+		}
+	}
+	
+	function open_leaderboard(){
+		location.href = "/leaderboard.php";
+	}
+	
+	function open_arti_page(){
+		location.href = "/hint.php";
+	}
+	
+	function open_player_search(){
+		location.href = "/player_search.php";
+	}
+	
+	function open_guild_search(){
+		location.href = "/guild_search.php";
+	}
+	
+	function open_staff_list(){
+		location.href = "/staff.php";
+	}
+	
+	function open_guild_transfer(){
+		location.href = "/guild_transfer.php";
+	}
+	
+	function open_ban_list(){
+		location.href = "/bans/bans.php";
+	}
+	
+	function displaymenu(ev){
+		if (menu_enabled === true){
+			var hubmenu = document.getElementById("prmenu");
+			hubmenu.style.left = (ev.clientX + document.body.scrollLeft + document.documentElement.scrollLeft) + "px";
+			hubmenu.style.top = (ev.clientY + document.body.scrollTop + document.documentElement.scrollTop) + "px";
+			hubmenu.style.display = "block";
+			ev.returnValue = false;
+		}
+		else
+		{
+			ev.returnValue = true;
+		}
+	}
+	
+	function user_click_hide(){
+		document.getElementById("prmenu").style.display = "none";
+	}
+	
+	function initialize_menu(){
+		document.getElementById("prmenu").innerHTML = "<center><span class=\"menutitle\"><img src=\"https://pr2hub.com/favicon.ico\" width=\"20px\" height=\"20px\"></img> Pr2Hub Menu</span><hr class=\"menudivider\"></hr><a href=\"#\" class=\"menulink\" id=\"banview\">View ban by ID</a><a href=\"#\" class=\"menulink\" id=\"setbg\">Set background</a><a href=\"#\" class=\"menulink\" id=\"skip_to_ban\">Go to specified page on bans</a><a href=\"#\" class=\"menulink\" id=\"menu_leaderboard\">Leaderboard</a><a href=\"#\" class=\"menulink\" id=\"ban_list\">Bans</a><a href=\"#\" class=\"menulink\" id=\"arti_hint\">Artifact hint</a><a href=\"#\" class=\"menulink\" id=\"srch_player\">Player search</a><a href=\"#\" class=\"menulink\" id=\"guild_srch\">Guild search</a><a href=\"#\" class=\"menulink\" id=\"staff_list\">Staff list</a><a href=\"#\" class=\"menulink\" id=\"transfer_guild\">Guild transfer</a></center>";
+	}
+	
+	window.onload = function(){
+		insert_css();
+		
+		insert_menu_code();
+		
+		initialize_menu();
+		
+		display_menu_hint();
+		
+		document.addEventListener("contextmenu", function(eventargs){
+			displaymenu(eventargs);
+		});
+		
+		document.addEventListener("click", function(){
+			user_click_hide();
+		});
+		
+		document.getElementById("banview").addEventListener("click", function(){
+			goto_ban();
+		});
+		
+		document.getElementById("setbg").addEventListener("click", function(){
+			set_background();
+		});
+		
+		document.getElementById("skip_to_ban").addEventListener("click", function(){
+			skip_to_page();
+		});
+		
+		document.getElementById("menu_leaderboard").addEventListener("click", function(){
+			open_leaderboard();
+		});
+		document.getElementById("arti_hint").addEventListener("click", function(){
+			open_arti_page();
+		});
+		
+		document.getElementById("srch_player").addEventListener("click", function(){
+			open_player_search();
+		});
+		
+		document.getElementById("guild_srch").addEventListener("click", function(){
+			open_guild_search();
+		});
+		
+		document.getElementById("staff_list").addEventListener("click", function(){
+			open_staff_list();
+		});
+		
+		document.getElementById("transfer_guild").addEventListener("click", function(){
+			open_guild_transfer();
+		});
+		
+		document.getElementById("ban_list").addEventListener("click", function(){
+			open_ban_list();
+		});
+		
+		document.addEventListener("keydown", function(keyinfo){
+			if (keyinfo.keyCode === 77){
+				if (menu_enabled === false){
+					menu_enabled = true;
+					hide_menu_hint();
+				}
+				else
+				{
+					menu_enabled = false;
+					unhide_menu_hint();
+				}
+			}
+		});
+	};


### PR DESCRIPTION
Alternative right click menu that can optionally be enabled on pr2hub for menu with missing page links.

Top notification showing how to enable:
https://gyazo.com/f1c360d809c5840469308293f68b7f36

Enabled menu when right clicking on page (appears to mouse position):
https://gyazo.com/313caf8c60189b207452b8097064f779

Preview of background change option:
https://gyazo.com/b10bac5c4386afeeffca947d4afe9b24

All of the things in menu is in javascript so it's only clientside change on background aswell so there's no risk of serverside code running. #