### PR TITLE
Fix server restarts

### DIFF
--- a/common/manage_socket/check_servers.php
+++ b/common/manage_socket/check_servers.php
@@ -9,7 +9,7 @@ require_once __DIR__ . '/management_fns.php';
 // output('testing if servers are running on server '.$my_ip.'... ');
 
 // test the policy server
-test_server(__DIR__ . '/../policy_server/run_policy.php', 'localhost', 843, $COMM_PASS, 0);
+test_server(__DIR__ . '/../../policy_server/run_policy.php', 'localhost', 843, $COMM_PASS, 0);
 
 // load all active servers
 $pdo = pdo_connect();
@@ -20,7 +20,7 @@ foreach ($servers as $server) {
     output($server->server_name);
     output($server->address);
     if ($server->address == $SERVER_IP) {
-        test_server(__DIR__ . '/../multiplayer_server/pr2.php', 'localhost', $server->port, $server->salt, $server->server_id);
+        test_server(__DIR__ . '/../../multiplayer_server/pr2.php', 'localhost', $server->port, $server->salt, $server->server_id);
     }
 }
 


### PR DESCRIPTION
The CRON that controls this script will need to be updated to make sure that it's executing with `/http_server/cron/minute.php`. I'm currently in the process of reworking the structure of the repo with organipocalypse, so this is a temporary fix.