### PR TITLE
Organipocalypse pt. 3.5 (fix errors caused by pt. 3)

### DIFF
--- a/common/manage_socket/socket_manage_fns.php
+++ b/common/manage_socket/socket_manage_fns.php
@@ -258,13 +258,19 @@ function talk_to_server($address, $port, $salt, $process_function, $receive = tr
 function poll_servers($servers, $message, $output = true, $server_ids = array())
 {
     $results = array();
+    $query = array();
 
     foreach ($servers as $server) {
-        if (count($server_ids) == 0 || array_search($server->server_id, $server_ids) !== false) {
-            $result = talk_to_server($server->address, $server->port, $server->salt, $message, $output);
-            $server->command = $message;
-            $server->result = json_decode($result);
-            $results[] = $server;
+        $id = (int) $server->server_id;
+        $query = new stdClass();
+
+        if (count($server_ids) == 0 || array_search($id, $server_ids) !== false) {
+            $result = (string) talk_to_server($server->address, $server->port, $server->salt, $message, $output);
+            $result = preg_replace('/[[:cntrl:]]/', '', $result); // remove control characters causing errors
+            $query->result = json_decode($result);
+            $query->command = $message;
+            $query->server_id = $id;
+            $results[$id] = $query;
         }
     }
 

--- a/http_server/fns/cron/cron_fns.php
+++ b/http_server/fns/cron/cron_fns.php
@@ -105,20 +105,24 @@ function get_recent_pms($pdo)
 
 function save_plays($pdo, $plays)
 {
-    foreach ($plays as $course => $plays) {
-        level_increment_play_count($pdo, $course, $plays);
+    if (!empty($plays)) {
+        foreach ($plays as $course => $plays) {
+            level_increment_play_count($pdo, $course, $plays);
+        }
     }
 }
 
 
 function save_gp($pdo, $server_id, $gp_array)
 {
-    foreach ($gp_array as $user_id => $gp) {
-        $user = user_select($pdo, $user_id);
-        $guild_id = $user->guild;
-        if ($guild_id > 0 && $server_id == $user->server_id) {
-            gp_increment($pdo, $user_id, $guild_id, $gp);
-            guild_increment_gp($pdo, $guild_id, $gp);
+    if (!empty($gp_array)) {
+        foreach ($gp_array as $user_id => $gp) {
+            $user = user_select($pdo, $user_id);
+            $guild_id = $user->guild;
+            if ($guild_id > 0 && $server_id == $user->server_id) {
+                gp_increment($pdo, $user_id, $guild_id, $gp);
+                guild_increment_gp($pdo, $guild_id, $gp);
+            }
         }
     }
 }
@@ -201,7 +205,7 @@ function update_artifact($pdo)
     $r->updated_time = $updated_time;
     $r_str = json_encode($r);
     
-    file_put_contents(__DIR__ . '/../www/files/artifact_hint.txt', $r_str);
+    file_put_contents(WWW_ROOT . '/files/artifact_hint.txt', $r_str);
     output($r->hint);
 }
 

--- a/http_server/fns/cron/fah_fns.php
+++ b/http_server/fns/cron/fah_fns.php
@@ -121,7 +121,14 @@ function fah_award_prizes($pdo, $name, $score, $prize_array)
         
         // get information from pr2, rank_tokens, and folding_at_home
         $hat_array = explode(',', pr2_select($pdo, $user_id)->hat_array);
-        $available_tokens = (int) rank_token_select($pdo, $user_id)->available_tokens;
+        $rank_token_row = rank_token_select($pdo, $user_id);
+        
+        // avoid getting object of false
+        if ($rank_token_row !== false) {
+            $available_tokens = (int) $rank_token_row->available_tokens;
+        } else {
+            $available_tokens = 0;
+        }
         
         // define columns
         $columns = array(

--- a/http_server/www/forgot_password.php
+++ b/http_server/www/forgot_password.php
@@ -12,7 +12,7 @@ $ip = get_ip();
 
 // sanitize email
 $problematic_chars = array('&', '"', "'", "<", ">");
-$email = str_replace($problematic_chars, '', $email);
+$email = str_replace($problematic_chars, '', $_POST['email']);
 
 try {
     // check for post


### PR DESCRIPTION
Some things broke. This fixes those things before continuing.

___

A couple of clarifications re: your vision (MrMaestro?) for how things will proceed:
 - What did you mean by "The `output_*` functions need to get overhauled or replaced"?
 - What's the status of the Templocalypse?

Also wanted to make sure you saw my response to this (posted by you on #484):
> What if we change all_fns.php to actually include all functions, and then set it up to get auto-loaded with each request? We could remove about a billion require_once statements from the repo.

My response:
> That could definitely work! The only thing I was skeptical about was loading a bunch of unneeded functions on each request. Additionally, we'd have to make sure no two function names are the same throughout the entire repo to prevent errors.
>
>If you're okay with all of this, then I'll get to it. To clarify: would you want all_fns.php to include all queries and both the multiplayer and http server functions, only both the multiplayer and http server functions (no queries), or just the contents of the http_server/fns/ folder? If we're going with options one or two, we could probably move both multiplayer_server/fns and http_server/fns into common and make http_server the public_html folder (instead of http_server/www/).