### PR TITLE
Fix guest logins

### DIFF
--- a/common/env.example.php
+++ b/common/env.example.php
@@ -36,5 +36,4 @@ $LEVEL_PASS_IV = 'la';
 $LOGIN_KEY = 'hello';
 $LOGIN_IV = 'there';
 
-$GUEST_PASS = 'this is the universal password for all guest accounts';
 $BLS_IP_PREFIX = 'no ddos plz';

--- a/common/queries/users/user_select_guest.php
+++ b/common/queries/users/user_select_guest.php
@@ -3,7 +3,18 @@
 function user_select_guest($pdo)
 {
     $stmt = $pdo->prepare('
-        SELECT user_id, name, email, register_ip, ip, time, register_time, power, status, read_message_id, guild, server_id
+        SELECT user_id,
+               name,
+               email,
+               register_ip,
+               ip,
+               time,
+               register_time,
+               power,
+               status,
+               read_message_id,
+               guild,
+               server_id
           FROM users
          WHERE power = 0
            AND status = "offline"

--- a/common/queries/users/user_select_guest.php
+++ b/common/queries/users/user_select_guest.php
@@ -3,7 +3,7 @@
 function user_select_guest($pdo)
 {
     $stmt = $pdo->prepare('
-        SELECT user_id, name
+        SELECT user_id, name, email, register_ip, ip, time, register_time, power, status, read_message_id, guild, server_id
           FROM users
          WHERE power = 0
            AND status = "offline"

--- a/http_server/www/login.php
+++ b/http_server/www/login.php
@@ -148,7 +148,8 @@ try {
     // sanity check: is the entered name and the one retrieved from the database identical?
     // this won't be triggered unless some real funny business is going on
     if (($token_login === false || !is_empty($login->user_name)) &&
-        strtolower($login->user_name) !== strtolower($user_name)
+        strtolower($login->user_name) !== strtolower($user_name) &&
+        $guest_login === false
     ) {
         throw new Exception("The names don't match. If this error persists, contact a member of the PR2 Staff Team.");
     }

--- a/http_server/www/login.php
+++ b/http_server/www/login.php
@@ -122,8 +122,14 @@ try {
         else {
             $user = pass_login($pdo, $user_name, $user_pass);
         }
+        
+        // see if they're trying to log into a guest
+        if ($user->power == 0 && $guest_login === false) {
+            throw new Exception("Direct logins to guest accounts are not permitted. ".
+                               'To play as a guest, click the "Play as Guest" button on the main menu.');
+        }
     }
-
+    
     // generate a login token for future requests
     $token = get_login_token($user->user_id);
     token_insert($pdo, $user->user_id, $token);

--- a/http_server/www/login.php
+++ b/http_server/www/login.php
@@ -63,8 +63,10 @@ try {
             'Platform Racing 2 has recently been updated. '.
             'Please refresh your browser to download the latest version.'
         );
-    } // sanity check: correct referrer?
-    //require_trusted_ref('log in');
+    }
+    
+    // correct referrer?
+    require_trusted_ref('log in');
 
     // rate limiting
     rate_limit('login-'.$ip, 5, 2, 'Please wait at least 5 seconds before trying to log in again.');
@@ -106,10 +108,8 @@ try {
     // guest login
     if (strtolower(trim($login->user_name)) == 'guest') {
         $guest_login = true;
-        $guest = user_select_guest($pdo);
-        $user = pass_login($pdo, $guest->name, $GUEST_PASS);
-        $login->user_name = $guest->name;
-        $login->user_pass = $GUEST_PASS;
+        $user = user_select_guest($pdo);
+        check_if_banned($pdo, $user->user_id, $ip);
     } // account login
     else {
         // token login

--- a/http_server/www/login.php
+++ b/http_server/www/login.php
@@ -125,7 +125,7 @@ try {
         
         // see if they're trying to log into a guest
         if ($user->power == 0 && $guest_login === false) {
-            throw new Exception("Direct logins to guest accounts are not permitted. ".
+            throw new Exception('Direct logins to guest accounts are not permitted. '.
                                'To play as a guest, click the "Play as Guest" button on the main menu.');
         }
     }

--- a/multiplayer_server/fns/process_fns.php
+++ b/multiplayer_server/fns/process_fns.php
@@ -93,10 +93,12 @@ function process_register_login($server_socket, $data)
                 $existing_player->write('message`You were disconnected because you logged in somewhere else.');
                 $existing_player->remove();
 
-                $socket->write('message`Your account was already running on this server. '.
-                    'It has been logged out to save your data. Please log in again.');
-                $socket->close();
-                $socket->onDisconnect();
+                if ($group > 0) {
+                    $socket->write('message`Your account was already running on this server. '.
+                        'It has been logged out to save your data. Please log in again.');
+                    $socket->close();
+                    $socket->onDisconnect();
+                }
             } elseif (\pr2\multi\LocalBans::isBanned($login_obj->user->name)) {
                 $socket->write('message`You have been kicked from this server for 30 minutes.');
                 $socket->close();

--- a/multiplayer_server/fns/process_fns.php
+++ b/multiplayer_server/fns/process_fns.php
@@ -93,17 +93,14 @@ function process_register_login($server_socket, $data)
                     $existing_player = $player_array[$user_id];
                     $existing_player->write('message`You were disconnected because you logged in somewhere else.');
                     $existing_player->remove();
-
                     $socket->write('message`Your account was already running on this server. '.
                         'It has been logged out to save your data. Please log in again.');
-                    $socket->close();
-                    $socket->onDisconnect();
                 } else {
                     $socket->write('message`This guest account is already online on this server. '.
                                   'Please try again later, or create your own account.');
-                    $socket->close();
-                    $socket->onDisconnect();
                 }
+                $socket->close();
+                $socket->onDisconnect();
             } elseif (\pr2\multi\LocalBans::isBanned($login_obj->user->name)) {
                 $socket->write('message`You have been kicked from this server for 30 minutes.');
                 $socket->close();

--- a/multiplayer_server/fns/process_fns.php
+++ b/multiplayer_server/fns/process_fns.php
@@ -89,13 +89,18 @@ function process_register_login($server_socket, $data)
                 $socket->close();
                 $socket->onDisconnect();
             } elseif (isset($player_array[$user_id])) {
-                $existing_player = $player_array[$user_id];
-                $existing_player->write('message`You were disconnected because you logged in somewhere else.');
-                $existing_player->remove();
-
                 if ($group > 0) {
+                    $existing_player = $player_array[$user_id];
+                    $existing_player->write('message`You were disconnected because you logged in somewhere else.');
+                    $existing_player->remove();
+
                     $socket->write('message`Your account was already running on this server. '.
                         'It has been logged out to save your data. Please log in again.');
+                    $socket->close();
+                    $socket->onDisconnect();
+                } else {
+                    $socket->write('message`This guest account is already online on this server. '.
+                                  'Please try again later, or create your own account.');
                     $socket->close();
                     $socket->onDisconnect();
                 }


### PR DESCRIPTION
I just reverted the guest login procedure to what it was before I attempted to fix the Kong badges.

Also, I added a line to `process_register_login()` in the socket server code that checks if the guest is online already. If so, it won't disconnect the guest that's online but it'll disconnect the person logging in. This way, people who know the guest password won't be able to troll others who are just visiting.

Edit: I also added a check for a direct guest account login in login.php.