### PR TITLE
Fix automatic artifact prize awards

### DIFF
--- a/http_server/www/place_artifact.php
+++ b/http_server/www/place_artifact.php
@@ -18,7 +18,9 @@ try {
     }
 
     // check referrer
-    require_trusted_ref();
+    if (!is_trusted_ref()) {
+        die('error=Incorrect referrer.');
+    }
 
     // rate limiting
     rate_limit(

--- a/multiplayer_server/fns/artifact_fns.php
+++ b/multiplayer_server/fns/artifact_fns.php
@@ -27,7 +27,7 @@ function save_finder($pdo, $player)
 {
     try {
         // does not count if you have found this artifact already
-        if (has_found_artifact($pdo, $player)) {
+        if (has_found_artifact($pdo, $player) === true) {
             return false;
         }
 
@@ -35,7 +35,8 @@ function save_finder($pdo, $player)
         artifacts_found_insert($pdo, $player->user_id);
 
         // check if you were the very first
-        if (!\pr2\multi\Artifact::$first_finder) {
+        $first_finder = (int) \pr2\multi\Artifact::$first_finder;
+        if ($first_finder === 0) {
             save_first_finder($pdo, $player);
         }
 
@@ -49,11 +50,11 @@ function save_finder($pdo, $player)
 // save and award prizes to the first finder
 function save_first_finder($pdo, $player)
 {
-    $user_id = $player->user_id;
+    $user_id = (int) $player->user_id;
 
     artifact_location_update_first_finder($pdo, $user_id);
     $artifact = artifact_location_select($pdo);
-    $first_finder = $artifact->first_finder;
+    $first_finder = (int) $artifact->first_finder;
 
     // false alarm, someone else found it first
     if ($first_finder !== $user_id) {


### PR DESCRIPTION
The artifact function's set first finder function isn't awarding prizes properly because it's looking for a false or null value instead of 0 for the first finder. This pull fixes that and tidies some other potential problem points as well.