### PR TITLE
Fix false positive

### DIFF
--- a/http_server/fns/data_fns.php
+++ b/http_server/fns/data_fns.php
@@ -1,19 +1,5 @@
 <?php
 
-// requests from a flash client will include this header (only used in logout.php)
-function is_from_game()
-{
-    $req_with = default_server("HTTP_X_REQUESTED_WITH", "");
-    $ref = default_server("HTTP_REFERER");
-
-    // let people type in the url manually
-    if (is_empty($ref)) {
-        return true;
-    }
-
-    // does the request originate from the flash player?
-    return strpos($req_with, "ShockwaveFlash/") === 0;
-}
 
 // check if player has an epic color option for a part
 function test_epic($color, $arr_str, $part)

--- a/http_server/www/logout.php
+++ b/http_server/www/logout.php
@@ -12,13 +12,6 @@ try {
     rate_limit('logout-'.$ip, 5, 2, 'Please wait at least 5 seconds before attempting to log out again.');
     rate_limit('logout-'.$ip, 60, 10, 'Only 10 logout requests per minute per IP are accepted.');
 
-    if (is_from_game() !== true) {
-        throw new Exception(
-            "It looks like you're not using PR2 to log out.	"
-            ."For security reasons, you may only log out from a PR2 client."
-        );
-    }
-
     if (isset($_COOKIE['token'])) {
         // connect to the db
         $pdo = pdo_connect();


### PR DESCRIPTION
Sometimes on logout, users will get an error saying they can only log out from the PR2 client. This check was originally put in place to prevent a CSRF exploit, but seeing as it creates false positives and fixes an issue that is non-destructive in the first place, I think it should be retired.