### PR TITLE
Limit publishing to newest

### DIFF
--- a/common/queries/new_levels/check_newest.php
+++ b/common/queries/new_levels/check_newest.php
@@ -11,7 +11,7 @@ function check_newest($pdo, $name, $ip)
     parse_str($newest, $levels_array);
     $levels_data = array_chunk($levels_array, 12);
 
-    foreach($levels_data as $level) {
+    foreach ($levels_data as $level) {
         $level_id = (int) $level[0];
         $level_creator = $level[7];
 

--- a/common/queries/new_levels/check_newest.php
+++ b/common/queries/new_levels/check_newest.php
@@ -1,0 +1,50 @@
+<?php
+
+// check newest pg 1 for 3 or more recent levels from this account or ip
+function check_newest($pdo, $name, $ip)
+{
+    // make our end array
+    $matches = array();
+
+    // account check
+    $newest = file_get_contents(WWW_ROOT . '/files/lists/newest/1');
+    parse_str($newest, $levels_array);
+    $levels_data = array_chunk($levels_array, 12);
+
+    foreach($levels_data as $level) {
+        $level_id = (int) $level[0];
+        $level_creator = $level[7];
+
+        if (strtolower($name) === strtolower($level_creator)) {
+            array_push($matches, $level_id);
+        }
+    }
+
+
+    // ip check
+    $stmt = $pdo->prepare('
+        SELECT level_id as id, ip
+          FROM pr2_new_levels
+      ORDER BY time DESC
+         LIMIT 0, 9
+    ');
+    $stmt->execute();
+    $results = $stmt->fetchAll(PDO::FETCH_OBJ);
+    
+    foreach ($results as $level) {
+        $level_id = (int) $level->id;
+        $pub_ip = $level->ip;
+
+        if ($pub_ip == $ip) {
+            if (!in_array($level_id, $matches)) {
+                array_push($matches, $level_id);
+            }
+        }
+    }
+    
+    if (count($matches) >= 3) {
+        return false;
+    } else {
+        return true;
+    }
+}

--- a/common/queries/new_levels/delete_from_newest.php
+++ b/common/queries/new_levels/delete_from_newest.php
@@ -1,0 +1,12 @@
+<?php
+
+// deletes a level from newest
+function delete_from_newest($pdo, $level_id)
+{
+    $stmt = $pdo->prepare('
+        DELETE FROM pr2_new_levels
+         WHERE level_id = :level_id
+    ');
+    $stmt->bindValue(":level_id", $level_id, PDO::PARAM_INT);
+    $stmt->execute();
+}

--- a/http_server/www/remove_level.php
+++ b/http_server/www/remove_level.php
@@ -4,6 +4,7 @@ header("Content-type: text/plain");
 
 require_once HTTP_FNS . '/all_fns.php';
 require_once QUERIES_DIR . '/levels/level_select.php'; // select a level
+require_once QUERIES_DIR . '/new_levels/delete_from_newest.php'; // delete from newest if present
 require_once QUERIES_DIR . '/staff/level_unpublish.php'; // unpublish a level
 require_once QUERIES_DIR . '/staff/actions/mod_action_insert.php'; // record the mod action
 
@@ -44,6 +45,7 @@ try {
     $l_note = $level->note;
 
     // unpublish the level
+    delete_from_newest($pdo, $level_id);
     level_unpublish($pdo, $level_id);
 
     //action log


### PR DESCRIPTION
We've had an issue in the past with level spam. As a fix, [Stxtics suggested](https://jiggmin2.com/forums/showthread.php?tid=851) that there be a limit to the number of levels that a user can publish to page 1 of newest at any given time. This pull adds that limit while still letting the user save their level.

Side note: I noticed that when a level gets unpublished, the level remains in `pr2_new_levels`. To make this pull work, I needed to count the number of levels from that table. I've added a function to `upload_level.php` and `remove_level.php` which delete the level from `pr2_new_levels` if it exists in that table.