### PR TITLE
Cosmetic/security updates, fixes

### DIFF
--- a/http_server/fns/pages/admin/contests/edit_contest_fns.php
+++ b/http_server/fns/pages/admin/contests/edit_contest_fns.php
@@ -107,4 +107,5 @@ function edit_contest($pdo, $contest, $admin)
     );
 
     header("Location: /contests/contests.php");
+    die();
 }

--- a/http_server/fns/pages/admin/set_campaign_fns.php
+++ b/http_server/fns/pages/admin/set_campaign_fns.php
@@ -120,8 +120,6 @@ function output_form($pdo, $message, $campaign_id)
         .'<br>'
         .'You can find a list of prizes and their corresponding IDs '
         .'<a href="part_ids.php" target="_blank">here</a>.</pre>';
-
-    output_footer();
 }
 
 function update($pdo, $admin, $campaign_id)

--- a/http_server/fns/pages/player_search_fns.php
+++ b/http_server/fns/pages/player_search_fns.php
@@ -19,7 +19,10 @@ function create_ban_list($bans)
 function find_user($pdo, $name)
 {
     // get id from name
-    $user_id = name_to_id($pdo, $name);
+    $user_id = name_to_id($pdo, $name, true);
+    if ($user_id === false) {
+        return false;
+    }
 
     // get player info from id
     $user = user_select_expanded($pdo, $user_id);

--- a/http_server/www/admin/admin_log.php
+++ b/http_server/www/admin/admin_log.php
@@ -26,7 +26,7 @@ try {
 
     //navigation
     output_pagination($start, $count);
-    echo('<p>---</p>');
+    echo '<p>---</p>';
 
 
     //output actions
@@ -35,11 +35,11 @@ try {
     }
 
 
-    echo('<p>---</p>');
+    echo '<p>---</p>';
     output_pagination($start, $count);
-    output_footer();
 } catch (Exception $e) {
     output_header('Error');
     echo 'Error: '.$e->getMessage();
+} finally {
     output_footer();
 }

--- a/http_server/www/admin/admin_log.php
+++ b/http_server/www/admin/admin_log.php
@@ -31,7 +31,7 @@ try {
 
     //output actions
     foreach ($actions as $row) {
-        echo("<p><span class='date'>$row->time</span> -- ".htmlspecialchars($row->message)."</p>");
+        echo "<p><span class='date'>$row->time</span> -- ".htmlspecialchars($row->message)."</p>";
     }
 
 

--- a/http_server/www/admin/contests/edit_contest.php
+++ b/http_server/www/admin/contests/edit_contest.php
@@ -2,7 +2,7 @@
 
 require_once HTTP_FNS . '/all_fns.php';
 require_once HTTP_FNS . '/output_fns.php';
-require_once HTTP_FNS . '/pages/admin/edit_contest_fns.php';
+require_once HTTP_FNS . '/pages/admin/contests/edit_contest_fns.php';
 require_once QUERIES_DIR . '/contests/contest_select.php';
 require_once QUERIES_DIR . '/contests/contest_update.php';
 require_once QUERIES_DIR . '/staff/actions/admin_action_insert.php';

--- a/http_server/www/admin/contests/edit_contest.php
+++ b/http_server/www/admin/contests/edit_contest.php
@@ -10,6 +10,7 @@ require_once QUERIES_DIR . '/staff/actions/admin_action_insert.php';
 $ip = get_ip();
 $action = find_no_cookie('action', 'form');
 $contest_id = (int) find_no_cookie('contest_id', 0);
+$header = false;
 
 try {
     // rate limiting
@@ -31,6 +32,7 @@ try {
     // form
     if ($action === 'form') {
         output_header('Edit Contest', true, true);
+        $header = true;
         output_form($contest);
         output_footer();
     } // add
@@ -44,7 +46,9 @@ try {
         throw new Exception('Invalid action specified.');
     }
 } catch (Exception $e) {
-    output_header('Error');
+    if ($header === false) {
+        output_header('Error');
+    }
     $error = $e->getMessage();
     echo "Error: $error<br><br><a href='javascript:history.back()'><- Go Back</a>";
     output_footer();

--- a/http_server/www/admin/contests/remove_prize.php
+++ b/http_server/www/admin/contests/remove_prize.php
@@ -11,6 +11,7 @@ require_once QUERIES_DIR . '/staff/actions/admin_action_insert.php';
 $ip = get_ip();
 $contest_id = (int) find('contest_id', 0);
 $action = find('action', 'form');
+$header = false;
 
 try {
     // rate limiting
@@ -42,6 +43,7 @@ try {
 
     // header
     output_header('Remove Contest Prize', true, true);
+    $header = true;
 
     // form
     if ($action === 'form') {
@@ -149,7 +151,9 @@ try {
         throw new Exception('Invalid action specified.');
     }
 } catch (Exception $e) {
-    output_header('Error');
+    if ($header === false) {
+        output_header('Error');
+    }
     $error = $e->getMessage();
     echo "Error: $error<br><br><a href='javascript:history.back()'><- Go Back</a>";
 } finally {

--- a/http_server/www/admin/contests/remove_prize.php
+++ b/http_server/www/admin/contests/remove_prize.php
@@ -144,9 +144,6 @@ try {
         echo "<br><br>";
         echo "<a href='add_prize.php?contest_id=$contest_id'>&lt;- Add Prize</a><br>";
         echo "<a href='/contests/contests.php'>&lt;- All Contests</a>";
-
-        // footer
-        output_footer();
     } // unknown handler
     else {
         throw new Exception('Invalid action specified.');
@@ -155,5 +152,6 @@ try {
     output_header('Error');
     $error = $e->getMessage();
     echo "Error: $error<br><br><a href='javascript:history.back()'><- Go Back</a>";
+} finally {
     output_footer();
 }

--- a/http_server/www/admin/player_deep_logins.php
+++ b/http_server/www/admin/player_deep_logins.php
@@ -32,7 +32,13 @@ try {
 
     // if there's a name set, let's get data from the db
     if ($name) {
-        $user_id = name_to_id($pdo, $name);
+        // check if the user exists, get user ID
+        $user_id = name_to_id($pdo, $name, true);
+        if ($user_id === false) {
+            throw new Exception("Could not find a user with that name.");
+        }
+
+        // get login data
         $login_count = recent_logins_count_by_user($pdo, $user_id);
         $logins = recent_logins_select($pdo, $user_id, true, $start, $count);
     }

--- a/http_server/www/admin/update_account.php
+++ b/http_server/www/admin/update_account.php
@@ -20,6 +20,7 @@ require_once QUERIES_DIR . '/staff/actions/admin_action_insert.php';
 // variables
 $user_id = find('id');
 $action = find('action', 'lookup');
+$header = false;
 
 try {
     // rate limiting
@@ -34,6 +35,7 @@ try {
 
     // header
     output_header('Update PR2 Account', true, true);
+    $header = true;
 
     // form
     if ($action === 'lookup') {
@@ -217,10 +219,12 @@ try {
 
         header("Location: player_deep_info.php?name1=" . urlencode($user_name));
     }
-    output_footer();
 } catch (Exception $e) {
-    output_header('Error');
+    if ($header === false) {
+        output_header("Error");
+    }
     $error = $e->getMessage();
     echo "Error: $error<br><br><a href='javascript:history.back()'><- Go Back</a>";
+} finally {
     output_footer();
 }

--- a/http_server/www/admin/update_account.php
+++ b/http_server/www/admin/update_account.php
@@ -33,12 +33,11 @@ try {
     //make sure you're an admin
     $admin = check_moderator($pdo, true, 3);
 
-    // header
-    output_header('Update PR2 Account', true, true);
-    $header = true;
-
     // form
     if ($action === 'lookup') {
+        output_header('Update PR2 Account', true, true);
+        $header = true;
+    
         echo '<form name="input" action="update_account.php" method="post">';
 
         $user = user_select($pdo, $user_id);

--- a/http_server/www/admin/update_account.php
+++ b/http_server/www/admin/update_account.php
@@ -217,6 +217,7 @@ try {
         );
 
         header("Location: player_deep_info.php?name1=" . urlencode($user_name));
+        die();
     }
 } catch (Exception $e) {
     if ($header === false) {

--- a/http_server/www/admin/update_guild.php
+++ b/http_server/www/admin/update_guild.php
@@ -147,6 +147,7 @@ try {
 
         // redirect
         header("Location: guild_deep_info.php?guild_id=" . urlencode($guild->guild_id));
+        die();
     }
 } catch (Exception $e) {
     if ($header === false) {

--- a/http_server/www/admin/update_guild.php
+++ b/http_server/www/admin/update_guild.php
@@ -19,6 +19,7 @@ require_once QUERIES_DIR . '/staff/actions/admin_action_insert.php';
 
 $guild_id = find('guild_id');
 $action = find('action', 'lookup');
+$header = false;
 
 try {
     // rate limiting
@@ -34,6 +35,7 @@ try {
     // lookup
     if ($action === 'lookup') {
         output_header('Update Guild', true, true);
+        $header = true;
 
         echo '<form name="input" action="update_guild.php" method="get">';
 
@@ -147,8 +149,10 @@ try {
         header("Location: guild_deep_info.php?guild_id=" . urlencode($guild->guild_id));
     }
 } catch (Exception $e) {
+    if ($header === false) {
+        output_header("Error");
+    }
     $error = $e->getMessage();
-    output_header("Error");
     echo "Error: $error<br><br><a href='javascript:history.back()'><- Go Back</a>";
     output_footer();
 }

--- a/http_server/www/backups/backups.php
+++ b/http_server/www/backups/backups.php
@@ -109,15 +109,18 @@ try {
     // display available backups
     echo '<br/>';
     $backups = level_backups_select($pdo, $user_id);
-    foreach ($backups as $row) {
-        echo "<p>$row->date: <b>".htmlspecialchars($row->title)
-            ."</b> v$row->version <a href='?action=restore&backup_id=$row->backup_id'>restore</a></p>";
+    if (!empty($backups)) {
+        foreach ($backups as $row) {
+            echo "<p>$row->date: <b>".htmlspecialchars($row->title)
+                ."</b> v$row->version <a href='?action=restore&backup_id=$row->backup_id'>restore</a></p>";
+        }
+    } else {
+        echo "<center>You haven't modified or deleted any levels in the past 30 days.</center>";
     }
-
-    output_footer();
 } catch (Exception $e) {
     $error = $e->getMessage();
     output_header("Level Backups");
     echo "Error: $error";
+} finally {
     output_footer();
 }

--- a/http_server/www/ban_user.php
+++ b/http_server/www/ban_user.php
@@ -177,10 +177,10 @@ try {
         die();
     } else {
         if ($banned_user_id == 0) {
-            echo("message=Guest [$banned_ip] has been banned for $duration seconds.");
+            echo "message=Guest [$banned_ip] has been banned for $duration seconds.";
         } else {
             $disp_name = htmlspecialchars($banned_name);
-            echo("message=$disp_name has been banned for $duration seconds.");
+            echo "message=$disp_name has been banned for $duration seconds.";
         }
     }
 } catch (Exception $e) {

--- a/http_server/www/ban_user.php
+++ b/http_server/www/ban_user.php
@@ -174,6 +174,7 @@ try {
 
     if ($using_mod_site == 'yes' && $redirect == 'yes') {
         header('Location: //pr2hub.com/mod/player_info.php?user_id='.$banned_user_id.'&force_ip='.$force_ip);
+        die();
     } else {
         if ($banned_user_id == 0) {
             echo("message=Guest [$banned_ip] has been banned for $duration seconds.");

--- a/http_server/www/bans/show_record.php
+++ b/http_server/www/bans/show_record.php
@@ -115,6 +115,6 @@ try {
 } catch (Exception $e) {
     $error = $e->getMessage();
     output_header('Error Fetching Ban', $is_mod);
-    echo "Error: $error";
+    echo "Error: $error<br><br><a href='javascript:history.back()'><- Go Back</a>";
     output_footer();
 }

--- a/http_server/www/contests/view_winners.php
+++ b/http_server/www/contests/view_winners.php
@@ -138,7 +138,8 @@ try {
     echo "<br><br><a href='contests.php'>&lt;- All Contests";
     output_footer();
 } catch (Exception $e) {
+    $error = htmlspecialchars($e->getMessage());
     output_header("Error");
-    echo 'Error: ' . $e->getMessage();
+    echo "Error: $error<br><br><a href='javascript:history.back()'><- Go Back</a>";
     output_footer();
 }

--- a/http_server/www/guild_search.php
+++ b/http_server/www/guild_search.php
@@ -55,7 +55,6 @@ try {
         $owner_name = htmlspecialchars($owner->name);
         $owner_url_name = htmlspecialchars(urlencode($owner->name));
         $owner_color = $group_colors[(int) $owner->power];
-        var_dump((int) guild_count_active($pdo, $guild_id));
         $active_count = (int) guild_count_active($pdo, $guild_id);
         $members = guild_select_members($pdo, $guild_id);
         $member_count = count($members);

--- a/http_server/www/guild_search.php
+++ b/http_server/www/guild_search.php
@@ -3,8 +3,10 @@
 require_once HTTP_FNS . '/all_fns.php';
 require_once HTTP_FNS . '/output_fns.php';
 require_once HTTP_FNS . '/pages/guild_search_fns.php';
+require_once HTTP_FNS . '/pr2/guild_count_active.php';
 require_once QUERIES_DIR . '/guilds/guild_name_to_id.php';
 require_once QUERIES_DIR . '/guilds/guild_select.php';
+require_once QUERIES_DIR . '/guilds/guild_select_active_member_count.php';
 require_once QUERIES_DIR . '/guilds/guild_select_members.php';
 require_once QUERIES_DIR . '/users/user_select_name_and_power.php';
 
@@ -25,7 +27,6 @@ try {
     // sanity check: is any data entered?
     if (is_empty($guild_name) && is_empty($guild_id, false)) {
         output_guild_search();
-        output_footer();
     } else {
         // connect
         $pdo = pdo_connect();
@@ -54,7 +55,13 @@ try {
         $owner_name = htmlspecialchars($owner->name);
         $owner_url_name = htmlspecialchars(urlencode($owner->name));
         $owner_color = $group_colors[(int) $owner->power];
-        // $active_count = (int) guild_count_active($pdo, $guild_id);
+        var_dump((int) guild_count_active($pdo, $guild_id));
+        if (function_exists('guild_count_active')) {
+            echo "GREAT SUCCESS";
+        } else {
+            echo "le troll";
+        }
+        $active_count = (int) guild_count_active($pdo, $guild_id);
         $members = guild_select_members($pdo, $guild_id);
         $member_count = count($members);
 
@@ -74,10 +81,9 @@ try {
         echo '<br>'
         ."<img src='https://pr2hub.com/emblems/$emblem'>"
         .'<br><br>'
-        ."Owner: <a href='player_search.php?name=$owner_url_name'
-        style='color: #$owner_color; text-decoration: underline;'>$owner_name
-        </a><br>"
-        ."Members: $member_count <br>" // | Active: $active_count
+        ."Owner: <a href='player_search.php?name=$owner_url_name' "
+        ."style='color: #$owner_color; text-decoration: underline;'>$owner_name</a><br>"
+        ."Members: $member_count | Active: $active_count<br>"
         ."GP Today: $gp_today | GP Total: $gp_total<br>"
         ."Created: $creation_date<br>"
         ."Last Active: $active_date<br>";

--- a/http_server/www/guild_search.php
+++ b/http_server/www/guild_search.php
@@ -112,10 +112,9 @@ try {
                 }
 
                 // member name column
-                echo "<a href='player_search.php?name=$member_url_name'
-                style='color: #$member_color; text-decoration: underline;'>
-                $member_name
-            </a></td>";
+                echo "<a href='player_search.php?name=$member_url_name'"
+                ."style='color: #$member_color; text-decoration: underline;'>"
+                ."$member_name</a></td>";
 
                 // gp today column
                 echo '<td>'
@@ -133,8 +132,7 @@ try {
 
         // if there are no members in the guild, show "This guild contains no members."
         } else {
-            echo '<br>'
-            ."This guild contains no members.";
+            echo '<br>This guild contains no members.';
         }
 
         // end the table

--- a/http_server/www/guild_search.php
+++ b/http_server/www/guild_search.php
@@ -56,11 +56,6 @@ try {
         $owner_url_name = htmlspecialchars(urlencode($owner->name));
         $owner_color = $group_colors[(int) $owner->power];
         var_dump((int) guild_count_active($pdo, $guild_id));
-        if (function_exists('guild_count_active')) {
-            echo "GREAT SUCCESS";
-        } else {
-            echo "le troll";
-        }
         $active_count = (int) guild_count_active($pdo, $guild_id);
         $members = guild_select_members($pdo, $guild_id);
         $member_count = count($members);

--- a/http_server/www/guild_transfer.php
+++ b/http_server/www/guild_transfer.php
@@ -164,22 +164,22 @@ try {
         $from = 'Fred the Giant Cactus <contact@jiggmin.com>';
         $to = $old_user->email;
         $subject = 'PR2 Guild Transfer Confirmation';
-        $body = "Howdy $safe_old_name,\n\nWe received a request to change the
-            owner of your guild $safe_guild_name to $safe_new_name. If you
-            requested this change, please click the link below to complete the
-            guild ownership transfer.\n\n
-            https://pr2hub.com/confirm_guild_transfer.php?code=$code\n\n
-            If you didn't request this change, you may need to change your password.\n\n
-            All the best,\nFred";
+        $body = "Howdy $safe_old_name,\n\nWe received a request to change the "
+            ."owner of your guild $safe_guild_name to $safe_new_name. If you "
+            ."requested this change, please click the link below to complete the "
+            ."guild ownership transfer.\n\n"
+            ."https://pr2hub.com/confirm_guild_transfer.php?code=$code\n\n"
+            ."If you didn't request this change, you may need to change your password.\n\n"
+            ."All the best,\nFred";
         send_email($from, $to, $subject, $body);
 
         // tell the world
-        echo "Almost done! We just sent a confirmation email to the email address
-            on your account. You'll still own your guild until you confirm the transfer.";
+        echo "Almost done! We just sent a confirmation email to the email address on your account. "
+            ."You'll still own your guild until you confirm the transfer.";
         output_footer();
     }
 } catch (Exception $e) {
     $message = $e->getMessage();
-    echo "Error: $message";
+    echo "Error: $message<br><br><a href='javascript:window.history.back()'>&lt;- Go Back</a>";
     output_footer();
 }

--- a/http_server/www/mod/ban.php
+++ b/http_server/www/mod/ban.php
@@ -59,10 +59,10 @@ try {
             .'</select>'
             .'<input type="submit" value="Submit" />'
         .'</form>';
-    output_footer();
 } catch (Exception $e) {
     $error = $e->getMessage();
     output_header('Error');
     echo "Error: $error";
+} finally {
     output_footer();
 }

--- a/http_server/www/mod/ban_edit.php
+++ b/http_server/www/mod/ban_edit.php
@@ -82,8 +82,6 @@ try {
             <p>Notes <textarea rows='4' cols='50' name='notes'>$ban->notes</textarea>
             <p><input type='submit' value='submit'></p>
             </form>";
-
-        output_footer();
     } else {
         throw new Exception('Unknown action specified.');
     }
@@ -91,5 +89,6 @@ try {
     $error = $e->getMessage();
     output_header('Error');
     echo "Error: $error";
+} finally {
     output_footer();
 }

--- a/http_server/www/mod/ban_edit.php
+++ b/http_server/www/mod/ban_edit.php
@@ -64,6 +64,7 @@ try {
 
         // redirect to the ban listing
         header("Location: https://pr2hub.com/bans/show_record.php?ban_id=$ban_id");
+        die();
     } elseif ($action == 'edit') {
         $ban = ban_select($pdo, $ban_id);
         output_header('Edit Ban', true);

--- a/http_server/www/mod/ip_info.php
+++ b/http_server/www/mod/ip_info.php
@@ -8,6 +8,7 @@ require_once QUERIES_DIR . '/users/users_select_by_ip.php';
 
 $ip = default_get('ip', '');
 $group_colors = ['7e7f7f', '047b7b', '1c369f', '870a6f'];
+$header = false;
 
 // mod check try/catch
 try {
@@ -67,6 +68,7 @@ try {
 
     // header
     output_header('IP Info', true);
+    $header = true;
 
     // start
     echo "<p>IP: $html_ip</p>";
@@ -134,11 +136,12 @@ try {
         echo "<a href='https://pr2hub.com/mod/player_info.php?user_id=$user_id' style='color: #$power_color'>$name</a>
             | Last Active: $active<br>";
     }
-
-    output_footer();
 } catch (Exception $e) {
-    $message = $e->getMessage();
-    output_header('Error');
-    echo "Error: $message";
+    if ($header === false) {
+        output_header('Error');
+    }
+    $error = $e->getMessage();
+    echo "Error: $error<br><br><a href='javascript:history.back()'><- Go Back</a>";
+} finally {
     output_footer();
 }

--- a/http_server/www/mod/lift_ban.php
+++ b/http_server/www/mod/lift_ban.php
@@ -48,6 +48,7 @@ try {
 
         //redirect to a page showing the lifted ban
         header("Location: /bans/show_record.php?ban_id=$ban_id");
+        die();
     } else {
         // get the ban
         $ban = ban_select($pdo, $ban_id);

--- a/http_server/www/mod/lift_ban.php
+++ b/http_server/www/mod/lift_ban.php
@@ -71,6 +71,6 @@ try {
 } catch (Exception $e) {
     $error = $e->getMessage();
     output_header('Error');
-    echo "Error: $error";
+    echo "Error: $error<br><br><a href='javascript:history.back()'><- Go Back</a>";
     output_footer();
 }

--- a/http_server/www/mod/mod_log.php
+++ b/http_server/www/mod/mod_log.php
@@ -26,19 +26,19 @@ try {
 
     //navigation
     output_pagination($start, $count);
-    echo('<p>---</p>');
+    echo '<p>---</p>';
 
     //output actions
     foreach ($actions as $row) {
         echo("<p><span class='date'>$row->time</span> -- ".htmlspecialchars($row->message)."</p>");
     }
 
-    echo('<p>---</p>');
+    echo '<p>---</p>';
     output_pagination($start, $count);
-    output_footer();
 } catch (Exception $e) {
     $error = $e->getMessage();
     output_header("Error");
     echo "Error: $error";
+} finally {
     output_footer();
 }

--- a/http_server/www/mod/mod_log.php
+++ b/http_server/www/mod/mod_log.php
@@ -30,7 +30,7 @@ try {
 
     //output actions
     foreach ($actions as $row) {
-        echo("<p><span class='date'>$row->time</span> -- ".htmlspecialchars($row->message)."</p>");
+        echo "<p><span class='date'>$row->time</span> -- ".htmlspecialchars($row->message)."</p>";
     }
 
     echo '<p>---</p>';

--- a/http_server/www/mod/player_info.php
+++ b/http_server/www/mod/player_info.php
@@ -139,7 +139,8 @@ try {
 } catch (Exception $e) {
     if ($e->getMessage() !== '') {
         $error = $e->getMessage();
-        echo "Error: $error";
+        echo "Error: $error<br><br><a href='javascript:history.back()'><- Go Back</a>";
     }
+} finally {
     output_footer();
 }

--- a/http_server/www/mod/reported_messages.php
+++ b/http_server/www/mod/reported_messages.php
@@ -28,7 +28,7 @@ try {
 
     // navigation
     output_pagination($start, $count);
-    echo('<p>---</p>');
+    echo '<p>---</p>';
 
     //output the messages
     foreach ($messages as $row) {
@@ -50,63 +50,53 @@ try {
             $class = 'not-archived';
         }
 
-        echo("	<br/>
-                <div class='$class'>
-                <p>
-                    <a href='player_info.php?user_id=$from_user_id&force_ip=$from_ip'>$from_name</a>
-                    sent this message to
-                    <a href='player_info.php?user_id=$to_user_id&force_ip=$reporter_ip'>$to_name</a>
-                    on $formatted_time
-                <p>
-                <p>$html_safe_message</p> ");
+        echo "<br><div class='$class'><p>".
+             "<a href='player_info.php?user_id=$from_user_id&force_ip=$from_ip'>$from_name</a> sent this message to ".
+             "<a href='player_info.php?user_id=$to_user_id&force_ip=$reporter_ip'>$to_name</a> on $formatted_time".
+             "<p><p>$html_safe_message</p>";
 
         if (!$archived) {
             $form_id = 'f'.$next_form_id;
             $button_id = 'b'.$next_form_id;
             $div_id = 'd'.$next_form_id++;
-            echo("<div id='$div_id'>
-                    <input id='$button_id' type='submit' value='Archive' />
-                    <br/>
-                    -- or --
-                    <br/>
-                    <form id='$form_id' action='../ban_user.php' method='post'>
-                        <input type='hidden' value='yes' name='using_mod_site'  />
-                        <input type='hidden' value='$from_name' name='banned_name' />
-                        <input type='hidden' value='$from_ip' name='force_ip' />
-                        <input type='submit' name='reason' value='Flaming' />
-                        <input type='submit' name='reason' value='Vulgar Language' />
-                        <input type='submit' name='reason' value='Password Scamming' />
-                        <input type='submit' name='reason' value='Spam' />
-                        <select name='duration'>
-                            <option value='60'>1 Minute</option>
-                            <option value='3600' selected='selected'>1 Hour</option>
-                            <option value='86400'>1 Day</option>
-                            <option value='604800'>1 Week</option>
-                            <option value='2592000'>1 Month</option>
-                            <option value='31536000'>1 Year</option>
-                        </select>
-                    </form>
-                </div>
-                <script>
-                    $('#$form_id').ajaxForm(function() {
-                        $('#$div_id').remove();
-                        $.get('archive_message.php', {message_id: $message_id});
-                    });
-                    $('#$button_id').click(function() {
-                        $('#$div_id').remove();
-                        $.get('archive_message.php', {message_id: $message_id});
-                    });
-                </script>
-            ");
+            echo "<div id='$div_id'>".
+                 "<input id='$button_id' type='submit' value='Archive'><br>".
+                 "-- or --<br>".
+                 "<form id='$form_id' action='../ban_user.php' method='post'>".
+                     "<input type='hidden' value='yes' name='using_mod_site'>".
+                     "<input type='hidden' value='$from_name' name='banned_name'>".
+                     "<input type='hidden' value='$from_ip' name='force_ip'>".
+                     "<input type='submit' name='reason' value='Flaming'>".
+                     "<input type='submit' name='reason' value='Vulgar Language'>".
+                     "<input type='submit' name='reason' value='Password Scamming'>".
+                     "<input type='submit' name='reason' value='Spam'>".
+                         "<select name='duration'>".
+                             "<option value='60'>1 Minute</option>".
+                             "<option value='3600' selected='selected'>1 Hour</option>".
+                             "<option value='86400'>1 Day</option>".
+                             "<option value='604800'>1 Week</option>".
+                             "<option value='2592000'>1 Month</option>".
+                             "<option value='31536000'>1 Year</option>".
+                         "</select>".
+                     "</form>".
+                 "</div>".
+                 "<script>
+                     $('#$form_id').ajaxForm(function() {
+                         $('#$div_id').remove();
+                         $.get('archive_message.php', {message_id: $message_id});
+                     });
+                     $('#$button_id').click(function() {
+                         $('#$div_id').remove();
+                         $.get('archive_message.php', {message_id: $message_id});
+                     });
+                 </script>";
         }
 
-        echo("
-                </div>
-                <p>&nbsp;</p>");
+        echo "</div><p>&nbsp;</p>";
     }
 
 
-    echo('<p>---</p>');
+    echo '<p>---</p>';
     output_pagination($start, $count);
 } catch (Exception $e) {
     $error = $e->getMessage();

--- a/http_server/www/mod/reported_messages.php
+++ b/http_server/www/mod/reported_messages.php
@@ -108,10 +108,10 @@ try {
 
     echo('<p>---</p>');
     output_pagination($start, $count);
-    output_footer();
 } catch (Exception $e) {
     $error = $e->getMessage();
     output_header("Error");
-    echo "Error: $error";
+    echo "Error: $error<br><br><a href='javascript:history.back()'><- Go Back</a>";
+} finally {
     output_footer();
 }

--- a/http_server/www/player_search.php
+++ b/http_server/www/player_search.php
@@ -13,6 +13,8 @@ output_header("Player Search");
 
 if (is_empty($name)) {
     output_search();
+    output_footer();
+    die();
 }
 
 try {
@@ -25,6 +27,9 @@ try {
 
     // find user
     $user = find_user($pdo, $name);
+    if ($user === false) {
+        throw new Exception("Could not find a user with that name.");
+    }
 
     // output
     output_search($name);


### PR DESCRIPTION
Motley spring cleaning! This update is dedicated to doing some of the things that probably should've been done a long time ago.

 - Adds `die()` calls after `header("Location: https://url.com/");` calls. This stops further execution of the script.
 - Fixes a few stray cosmetic errors with headers/footers either not displaying or displaying when they're not supposed to be.
 - Changes a bit of the code structure in certain spots (i.e. moving `output_footer()` present in both `try` and `catch` to a `finally` block, removing parenthesis around text when using `echo`).
 - Fixes admin contest editing (require link broke).
 - Adds "Go Back" buttons to some pages on error or success.