### PR TITLE
Prevent double player search

### DIFF
--- a/http_server/fns/pages/player_search_fns.php
+++ b/http_server/fns/pages/player_search_fns.php
@@ -29,17 +29,10 @@ function find_user($pdo, $name)
 
 
 // output gwibble option for /mod/player_info.php vs player_search.php
-function output_search($name = '', $gwibble = true)
+function output_search($name = '')
 {
     // safety first
     $safe_name = htmlspecialchars($name);
-
-    // gwibble output
-    if ($gwibble === true) {
-        echo '<center>'
-            .'<font face="Gwibble" class="gwibble">-- Player Search --</font>'
-            .'<br><br>';
-    }
 
     // output search
     echo '<form method="get">'

--- a/http_server/www/player_search.php
+++ b/http_server/www/player_search.php
@@ -13,6 +13,7 @@ output_header("Player Search");
 
 if (is_empty($name)) {
     output_search();
+    die();
 }
 
 try {


### PR DESCRIPTION
Adding `die();` will prevent outputting two player search input boxes and also prevent searching an empty name when you enter the page.

![image](https://user-images.githubusercontent.com/35195062/43213145-7f68c422-903e-11e8-98fc-bd505546266a.png)