### PR TITLE
Convert warnings to mutes

### DIFF
--- a/multiplayer_server/Mutes.php
+++ b/multiplayer_server/Mutes.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace pr2\multi;
+
+class Mutes
+{
+
+    private static $arr = array();
+
+
+    public static function add($user_name, $duration = 60)
+    {
+        $mute = new \stdClass();
+        $mute->user_name = $user_name;
+        $mute->expire_time = time() + $duration;
+        self::$arr[] = $mute;
+    }
+
+
+    public static function remove($user_name)
+    {
+        $len = count(self::$arr);
+        for ($i=0; $i<$len; $i++) {
+            $mute = self::$arr[$i];
+            if (strtolower(trim($mute->user_name)) == strtolower(trim($user_name))) {
+                array_splice(self::$arr, $i, 1);
+                return true;
+            }
+            continue;
+        }
+        return false;
+    }
+
+
+    public static function isMuted($user_name)
+    {
+        $isMuted = false;
+        $muted_until = self::getMute($user_name)->expire_time;
+        if ($muted_until > 0 && $muted_until > time()) {
+            $isMuted = true;
+        }
+        return $isMuted;
+    }
+
+
+    public static function remainingTime($user_name)
+    {
+        if (self::isMuted($user_name) === true) {
+            return self::getMute($user_name)->expire_time - time();
+        }
+    }
+
+
+    private static function getMute($user_name)
+    {
+        foreach (self::$arr as $mute) {
+            if (strtolower(trim($mute->user_name)) == strtolower(trim($user_name))) {
+                return $mute;
+            }
+        }
+
+        // return a blank mute if we got here
+        $mute = new \stdClass();
+        $mute->user_name = null;
+        $mute->expire_time = 0;
+        return $mute; 
+    }
+
+
+    public static function removeExpired()
+    {
+        $time = time();
+        $len = count(self::$arr);
+        for ($i=0; $i<$len; $i++) {
+            $mute = self::$arr[ $i ];
+            if ($mute->expire_time < $time) {
+                array_splice(self::$arr, $i, 1);
+                $len--;
+                $i--;
+            }
+        }
+    }
+}

--- a/multiplayer_server/Mutes.php
+++ b/multiplayer_server/Mutes.php
@@ -63,7 +63,7 @@ class Mutes
         $mute = new \stdClass();
         $mute->user_name = null;
         $mute->expire_time = 0;
-        return $mute; 
+        return $mute;
     }
 
 

--- a/multiplayer_server/PR2SocketServer.php
+++ b/multiplayer_server/PR2SocketServer.php
@@ -15,7 +15,8 @@ class PR2SocketServer extends \chabot\SocketServer
     public function onTimer()
     {
         TemporaryItems::removeExpired();
-        LocalBans::removeExpired();
+        ServerBans::removeExpired();
+        Mutes::removeExpired();
         LoiterDetector::check();
     }
 }

--- a/multiplayer_server/Player.php
+++ b/multiplayer_server/Player.php
@@ -77,8 +77,6 @@ class Player
     public $finished_race = false;
     public $quit_race = false;
 
-    public $chat_ban = 0;
-
     public $domain;
     public $ip;
 
@@ -884,20 +882,27 @@ class Player
                 }
             } // --- send chat message --- \\
             else {
+                // get time of mute expiry
+                $isMuted = Mutes::isMuted($this->name);
+
                 // guest check
                 if ($this->group <= 0 || $this->guest == true) {
                     $this->write("systemChat`Sorries, guests can't send chat messages.");
                 } // rank 3 check
                 elseif ($this->active_rank < 3 && $this->group < 2) {
                     $this->write('systemChat`Sorries, you must be rank 3 or above to chat.');
-                } // chat ban check (warnings, auto-warn)
-                elseif ($this->chat_ban > time() && ($this->group < 2 || $this->temp_mod === true)) {
-                    $chat_ban_seconds = $this->chat_ban - time();
-                    $this->write("systemChat`You have been temporarily banned from the chat. ".
-                        "The ban will be lifted in $chat_ban_seconds seconds.");
+                } // muted check (warnings, auto-warn, manual mute duration)
+                elseif ($isMuted === true
+                    && ($this->group < 2
+                        || $this->temp_mod === true
+                        || ($guild_id != 0 && $this->server_owner === false))
+                ) {
+                    $cb_secs = (int) Mutes::remainingTime($this->name);
+                    $this->write("systemChat`You have been temporarily muted from the chat. ".
+                        "The mute will be lifted in $cb_secs seconds.");
                 } // spam check
                 elseif ($this->getChatCount() > 6 && ($this->group < 2 || $this->temp_mod === true)) {
-                    $this->chat_ban = time() + 60;
+                    Mutes::add($this->name, 60);
                     $this->write('systemChat`Slow down a bit, yo.');
                 } // illegal character in username/message check
                 elseif (strpos($this->name, '`') !== false || strpos($chat_message, '`') !== false) {
@@ -1571,7 +1576,6 @@ class Player
         $this->worn_hat_array = null;
         $this->finished_race = null;
         $this->quit_race = null;
-        $this->chat_ban = null;
         $this->domain = null;
         $this->ip = null;
         $this->temp_mod = null;

--- a/multiplayer_server/ServerBans.php
+++ b/multiplayer_server/ServerBans.php
@@ -2,7 +2,7 @@
 
 namespace pr2\multi;
 
-class LocalBans
+class ServerBans
 {
 
     private static $arr = array();
@@ -22,7 +22,7 @@ class LocalBans
         $len = count(self::$arr);
         for ($i=0; $i<$len; $i++) {
             $ban = self::$arr[$i];
-            if ($ban->user_name == $user_name) {
+            if (strtolower(trim($ban->user_name)) == strtolower(trim($user_name))) {
                 array_splice(self::$arr, $i, 1);
                 return true;
             }
@@ -36,12 +36,12 @@ class LocalBans
     {
         $match = false;
         foreach (self::$arr as $ban) {
-            if ($ban->user_name == $user_name) {
+            if (strtolower(trim($ban->user_name)) == strtolower(trim($user_name))) {
                 $match = true;
                 break;
             }
         }
-        return( $match );
+        return $match;
     }
 
 

--- a/multiplayer_server/fns/client/moderation.php
+++ b/multiplayer_server/fns/client/moderation.php
@@ -160,7 +160,6 @@ function client_warn($socket, $data)
 // unmute a player
 function client_unmute($socket, $data)
 {
-    global $pdo, $guild_id, $server_name;
     $name = $data;
 
     // get some info

--- a/multiplayer_server/fns/client/moderation.php
+++ b/multiplayer_server/fns/client/moderation.php
@@ -15,11 +15,11 @@ function client_kick($socket, $data)
     $safe_kname = htmlspecialchars($name);
 
     // if the player actually has the power to do what they're trying to do, then do it
-    if ($mod->group >= 2 && ($kicked->group < 2 || ($mod->server_owner == true && $kicked != $mod))) {
+    if ($mod->group >= 2 && (@$kicked->group < 2 || ($mod->server_owner == true && $kicked != $mod))) {
         if (isset($kicked)) {
             $mod_url = userify($mod, $mod->name);
             $kicked_url = userify($kicked, $name);
-            
+
             // kick the user
             \pr2\multi\ServerBans::add($name);
             $kicked->remove();

--- a/multiplayer_server/fns/client/moderation.php
+++ b/multiplayer_server/fns/client/moderation.php
@@ -1,5 +1,6 @@
 <?php
 
+
 // kick a player
 function client_kick($socket, $data)
 {
@@ -15,7 +16,7 @@ function client_kick($socket, $data)
 
     // if the player actually has the power to do what they're trying to do, then do it
     if ($mod->group >= 2 && ($kicked->group < 2 || ($mod->server_owner == true && $kicked != $mod))) {
-        \pr2\multi\LocalBans::add($name);
+        \pr2\multi\ServerBans::add($name);
 
         if (isset($kicked)) {
             $mod_url = userify($mod, $mod->name);
@@ -57,7 +58,7 @@ function client_kick($socket, $data)
 }
 
 
-//--- unkick a player -------------------------------------------------------------
+// unkick a player
 function client_unkick($socket, $data)
 {
     global $pdo, $guild_id, $server_name;
@@ -69,8 +70,8 @@ function client_unkick($socket, $data)
 
     // if the player actually has the power to do what they're trying to do, then do it
     if (($mod->group >= 2 && $mod->temp_mod === false) || $mod->server_owner === true) {
-        if (\pr2\multi\LocalBans::isBanned($name) === true) {
-            \pr2\multi\LocalBans::remove($name);
+        if (\pr2\multi\ServerBans::isBanned($name) === true) {
+            \pr2\multi\ServerBans::remove($name);
 
             // unkick them, yo
             $mod->write("message`$unkicked_name has been unkicked! Hooray for second chances!");
@@ -92,7 +93,7 @@ function client_unkick($socket, $data)
 }
 
 
-//--- warn a player -------------------------------------------------------------
+// administer a chat warning
 function client_warn($socket, $data)
 {
     list($name, $num) = explode("`", $data);
@@ -126,11 +127,19 @@ function client_warn($socket, $data)
     }
 
     // if they're a mod, and the user is on this server, warn the user
-    if ($mod->group >= 2 && isset($warned) && ($warned->group < 2 || $mod->server_owner == true)) {
-        $warned->chat_ban = time() + $time;
-    } // if they're a mod but the user isn't online, tell them
-    elseif ($mod->group >= 2 && !isset($warned)) {
-        $mod->write("message`Error: Could not find a user with the name \"$safe_wname\" on this server.");
+    if ($mod->group >= 2) {
+        // if the target isn't online, tell the mod
+        if (!isset($warned)) {
+            $mod->write("message`Error: \"$safe_wname\" is not currently on this server, "
+                .'but the mute will be applied anyway.'
+            );
+        }
+
+        // remove existing mutes, then mute
+        if (\pr2\multi\Mutes::isMuted($name) === true) {
+            \pr2\multi\Mutes::remove($name);
+        }
+        \pr2\multi\Mutes::add($name, $time);
     } // if they aren't a mod, tell them
     else {
         $mod->write("message`Error: You lack the power to warn $safe_wname.");
@@ -142,15 +151,39 @@ function client_warn($socket, $data)
         $warned_url = userify($warned, $name);
 
         $mod->chat_room->sendChat("systemChat`$mod_url has given ".
-            "$warned_url $num $w_str. They have been banned from the chat ".
+            "$warned_url $num $w_str. They have been muted from the chat ".
             "for $time seconds.");
     }
 }
 
 
+// unmute a player
+function client_unmute($socket, $data)
+{
+    global $pdo, $guild_id, $server_name;
+    $name = $data;
+
+    // get some info
+    $mod = $socket->getPlayer();
+    $unmuted_name = htmlspecialchars($name);
+
+    // if the player actually has the power to do what they're trying to do, then do it
+    if (($mod->group >= 2 && $mod->temp_mod === false) || $mod->server_owner === true) {
+        if (\pr2\multi\Mutes::isMuted($name) === true) {
+            \pr2\multi\Mutes::remove($name);
+
+            // unmute them, yo
+            $mod->write("message`$unmuted_name has been unmuted! Hooray for speech!");
+        } else {
+            $mod->write("message`Error: $unmuted_name isn't muted.");
+        }
+    } else {
+        $mod->write("message`Error: You lack the power to unmute $unmuted_name.");
+    }
+}
 
 
-//--- ban a player -------------------------------------------------------
+// ban a player
 function client_ban($socket, $data)
 {
     list($banned_name, $seconds, $reason) = explode("`", $data);
@@ -212,8 +245,7 @@ function client_ban($socket, $data)
 }
 
 
-
-//--- promote a player to a moderator -------------------------------------
+// promote a player to a moderator
 function client_promote_to_moderator($socket, $data)
 {
     list($name, $type) = explode("`", $data);
@@ -260,7 +292,7 @@ function client_promote_to_moderator($socket, $data)
 }
 
 
-//-- demote a moderator ------------------------------------------------------------------
+// demote a moderator
 function client_demote_moderator($socket, $name)
 {
     // get player info

--- a/multiplayer_server/fns/client/moderation.php
+++ b/multiplayer_server/fns/client/moderation.php
@@ -130,9 +130,8 @@ function client_warn($socket, $data)
     if ($mod->group >= 2) {
         // if the target isn't online, tell the mod
         if (!isset($warned)) {
-            $mod->write("message`Error: \"$safe_wname\" is not currently on this server, "
-                .'but the mute will be applied anyway.'
-            );
+            $mod->write("message`Error: \"$safe_wname\" is not currently on this server, ".
+                'but the mute will be applied anyway.');
         }
 
         // remove existing mutes, then mute

--- a/multiplayer_server/fns/client/moderation.php
+++ b/multiplayer_server/fns/client/moderation.php
@@ -21,6 +21,9 @@ function client_kick($socket, $data)
             $kicked_url = userify($kicked, $name);
 
             // kick the user
+            if (\pr2\multi\ServerBans::isBanned($name) === true) {
+                \pr2\multi\ServerBans::remove($name); // remove existing kick if there is one
+            }
             \pr2\multi\ServerBans::add($name);
             $kicked->remove();
             $mod->write("message`$safe_kname has been kicked from this server for 30 minutes.");

--- a/multiplayer_server/fns/data_fns.php
+++ b/multiplayer_server/fns/data_fns.php
@@ -14,8 +14,8 @@ function sort_chat_room_array($a, $b)
 // build a url
 function urlify($link, $disp, $color = '#0000FF', $bt_replace = true)
 {
-    $link = htmlspecialchars($link);
-    $disp = htmlspecialchars($disp);
+    $link = htmlspecialchars($link, ENT_QUOTES);
+    $disp = htmlspecialchars($disp, ENT_QUOTES);
     
     // replace backticks with html code to prevent errors
     if ($bt_replace === true) {
@@ -39,7 +39,7 @@ function group_color($group)
 // determine a user's display info
 function userify($player, $name, $power = null)
 {
-    $name = htmlspecialchars($name);
+    $name = htmlspecialchars($name, ENT_QUOTES);
 
     if (isset($player) && isset($player->group) && is_null($power)) {
         $color = group_color($player->group);

--- a/multiplayer_server/fns/process_fns.php
+++ b/multiplayer_server/fns/process_fns.php
@@ -101,7 +101,7 @@ function process_register_login($server_socket, $data)
                 }
                 $socket->close();
                 $socket->onDisconnect();
-            } elseif (\pr2\multi\LocalBans::isBanned($login_obj->user->name)) {
+            } elseif (\pr2\multi\ServerBans::isBanned($login_obj->user->name)) {
                 $socket->write('message`You have been kicked from this server for 30 minutes.');
                 $socket->close();
                 $socket->onDisconnect();

--- a/multiplayer_server/pr2.php
+++ b/multiplayer_server/pr2.php
@@ -31,23 +31,6 @@ require_once PR2_FNS_DIR . '/staff/demod.php';
 require_once PR2_FNS_DIR . '/staff/promote_to_moderator.php';
 require_once PR2_FNS_DIR . '/staff/server_owner.php';
 
-require_once PR2_ROOT . '/Artifact.php';
-require_once PR2_ROOT . '/loadup.php';
-require_once PR2_ROOT . '/Player.php';
-require_once PR2_ROOT . '/PR2SocketServer.php';
-require_once PR2_ROOT . '/PR2Client.php';
-require_once PR2_ROOT . '/CourseBox.php';
-require_once PR2_ROOT . '/ChatMessage.php';
-require_once PR2_ROOT . '/GuildPoints.php';
-require_once PR2_ROOT . '/HappyHour.php';
-require_once PR2_ROOT . '/RaceStats.php';
-require_once PR2_ROOT . '/Hat.php';
-require_once PR2_ROOT . '/LocalBans.php';
-require_once PR2_ROOT . '/LoiterDetector.php';
-require_once PR2_ROOT . '/TemporaryItems.php';
-require_once PR2_ROOT . '/Perks.php';
-require_once PR2_ROOT . '/RankupCalculator.php';
-
 require_once PR2_ROOT . '/parts/Bodies.php';
 require_once PR2_ROOT . '/parts/Feet.php';
 require_once PR2_ROOT . '/parts/Hats.php';
@@ -63,6 +46,24 @@ require_once PR2_ROOT . '/rooms/modes/deathmatch.php';
 require_once PR2_ROOT . '/rooms/modes/eggs.php';
 require_once PR2_ROOT . '/rooms/modes/objective.php';
 require_once PR2_ROOT . '/rooms/modes/race.php';
+
+require_once PR2_ROOT . '/Artifact.php';
+require_once PR2_ROOT . '/CourseBox.php';
+require_once PR2_ROOT . '/ChatMessage.php';
+require_once PR2_ROOT . '/GuildPoints.php';
+require_once PR2_ROOT . '/HappyHour.php';
+require_once PR2_ROOT . '/Hat.php';
+require_once PR2_ROOT . '/Mutes.php';
+require_once PR2_ROOT . '/loadup.php';
+require_once PR2_ROOT . '/LoiterDetector.php';
+require_once PR2_ROOT . '/Perks.php';
+require_once PR2_ROOT . '/Player.php';
+require_once PR2_ROOT . '/PR2SocketServer.php';
+require_once PR2_ROOT . '/PR2Client.php';
+require_once PR2_ROOT . '/RaceStats.php';
+require_once PR2_ROOT . '/RankupCalculator.php';
+require_once PR2_ROOT . '/ServerBans.php';
+require_once PR2_ROOT . '/TemporaryItems.php';
 
 output("Initializing startup...");
 


### PR DESCRIPTION
This pull separates chat bans from the player object in favor of a server-logging system (like how kicking works). The difference will be negligible to a normal player, but this will allow us to do a lot more with chat bans than before, as well as abolishing warn evading by logging out and back into an account with an active warning.

In the future, with regards to mutes/warnings, I hope to:
 - Add a chat command that will allow a mod to mute a user for up to a day
 - Add an unwarn chat command (the function is already in `fns/client/moderation.php`)
 - Move all chat commands to a different php file so they aren't cluttering `Player.php`

This also fixes a bug with kicking where if a user attempts to log in using a different case as was previously used (i.e. JIGGMIN instead of Jiggmin), the kick doesn't have any effect.