### PR TITLE
Improve server logging, tidy code

### DIFF
--- a/common/manage_socket/socket_manage_fns.php
+++ b/common/manage_socket/socket_manage_fns.php
@@ -36,6 +36,7 @@ function restart_server($script, $address, $port, $salt, $server_id)
 {
     $pid = read_pid($port);
     shut_down_server($pid, $address, $port, $salt);
+    sleep(1);
     start_server($script, $port, $server_id);
 }
 
@@ -78,11 +79,7 @@ function test_server($script, $address, $port, $salt, $server_id)
         output("GOOD - Server #$server_id is running.");
     } else {
         output("BAD - Bad/No response from server #$server_id.");
-
-        $pid = read_pid($port);
-        shut_down_server($pid, $address, $port, $salt);
-
-        start_server($script, $port, $server_id);
+        restart_server($script, $address, $port, $salt, $server_id);
     }
 
     // tell the world
@@ -93,15 +90,15 @@ function test_server($script, $address, $port, $salt, $server_id)
 // starts a server
 function start_server($script, $port, $server_id)
 {
-    output("start_server: $script, $port");
+    output("STARTING SERVER | Script: $script | Port: $port");
 
-    $log = '/home/jiggmin/pr2/log/'.$port.'-'.date("Fj-Y-g:ia").'.log';
+    $log = ROOT_DIR . '/../pr2/log/' . $port . '-' . date("Fj-Y-g:ia") . '.log';
     $command = "nohup php $script $server_id > $log & echo $!";
     output("Executing command: $command");
     $pid = exec($command);
 
     write_pid($pid, $port);
-    return($pid);
+    return $pid;
 }
 
 
@@ -125,10 +122,10 @@ function shut_down_server($pid, $address, $port, $salt)
     }
 
     // tell the world
-    if ($kill_res === true) {
+    if (@$kill_res === true) {
         output("Shutdown of server running at $address:$port successful.");
     } else {
-        output("Unable to kill port. The server could already be shut down.");
+        output("A new server can now be started on port $port.");
     }
 }
 
@@ -136,8 +133,8 @@ function shut_down_server($pid, $address, $port, $salt)
 // gets the pid file
 function get_pid_file($port)
 {
-    $pid_file = '/home/jiggmin/pr2/pid/'.$port.'.txt';
-    return($pid_file);
+    $pid_file = ROOT_DIR . '/../pr2/pid/' . $port . '.txt';
+    return $pid_file;
 }
 
 
@@ -165,19 +162,19 @@ function read_pid($port)
     if ($handle !== false) {
         $pid = fread($handle, 999);
         fclose($handle);
-        output("PID is: $pid \n");
+        output("PID is: $pid");
     } else {
         output("The PID file does not exist.");
     }
-    return($pid);
+    return $pid;
 }
 
 
 // kills a port
 function kill_pid($pid)
 {
-    if ($pid != null && $pid != 0 && $pid != '') {
-        system("kill ".$pid, $k);
+    if ($pid != null && $pid != 0 && $pid != '' && $pid != false) {
+        system("kill " . $pid, $k);
         $pid = null;
         if (!$k) {
             return true;
@@ -274,7 +271,7 @@ function poll_servers($servers, $message, $output = true, $server_ids = array())
         }
     }
 
-    return($results);
+    return $results;
 }
 
 

--- a/multiplayer_server/Player.php
+++ b/multiplayer_server/Player.php
@@ -602,6 +602,7 @@ class Player
                             $admin_id,
                             $ip
                         );
+                        output("$this->name initiated a server shutdown.");
                         shutdown_server();
                     }
                 } else {

--- a/multiplayer_server/rooms/Game.php
+++ b/multiplayer_server/rooms/Game.php
@@ -502,7 +502,7 @@ class Game extends Room
                 $welcome_back_bonus = 1000;
             } // level bonus
             else {
-                $level_bonus = $this->appyExpCurve($player, 25 * $time_mod);
+                $level_bonus = $this->applyExpCurve($player, 25 * $time_mod);
 
                 $completed_perc = 0;
                 
@@ -542,7 +542,7 @@ class Game extends Room
                 $race_stats = $this->finish_array[$i];
                 if ($race_stats->rank < 100 && PR2SocketServer::$no_prizes === false) {
                     $exp_gain = ($race_stats->rank+5) * $time_mod;
-                    $exp_gain = ceil($this->appyExpCurve($player, $exp_gain));
+                    $exp_gain = ceil($this->applyExpCurve($player, $exp_gain));
                 } else {
                     $exp_gain = 0;
                 }
@@ -1049,7 +1049,7 @@ class Game extends Room
     }
 
 
-    private function appyExpCurve($player, $exp)
+    private function applyExpCurve($player, $exp)
     {
         if ($player->exp_today < 5000) {
             $tier = 2.0;


### PR DESCRIPTION
The main focus of this pull is to tidy the output when it comes to logging things in server logs. This just makes messages easier to understand if you're trying to debug something that happened.

Technical details:
- restart_server: add sleep(1) between shutdown and start
- test_server: delegate to restart_server
- start_server: tidy code and log output
- shut_down_server: more accurate logging
- get_pid_file: tidy code
- read_pid: tidy code and log output

Also:
- Added admin name on server restart to the log (Player.php)
- Fixed a typo in Game.php (appyExpCurve -> applyExpCurve; sorry, couldn't resist)

With that, I believe every typo in the repo is gone. It was not an easy journey. We have come far since January.