### PR TITLE
Don't let campaign levels be deleted

### DIFF
--- a/common/queries/campaign/campaign_level_select_by_id.php
+++ b/common/queries/campaign/campaign_level_select_by_id.php
@@ -1,0 +1,19 @@
+<?php
+
+function campaign_level_select_by_id($pdo, $level_id)
+{
+    $stmt = $pdo->prepare('
+        SELECT campaign, level_num
+        FROM pr2_campaign
+        WHERE level_id = :level_id
+        LIMIT 1
+    ');
+    $stmt->bindValue(":level_id", $level_id, PDO::PARAM_INT);
+    $result = $stmt->execute();
+
+    if ($result === false) {
+        throw new Exception('Could not perform query campaign_level_select_by_id.');
+    }
+
+    return $stmt->fetchAll(PDO::FETCH_OBJ);
+}

--- a/http_server/www/delete_level.php
+++ b/http_server/www/delete_level.php
@@ -4,6 +4,7 @@ header("Content-type: text/plain");
 
 require_once HTTP_FNS . '/all_fns.php';
 require_once HTTP_FNS . '/pr2/pr2_fns.php';
+require_once QUERIES_DIR . '/campaign/campaign_level_select_by_id.php';
 require_once QUERIES_DIR . '/levels/level_select.php';
 require_once QUERIES_DIR . '/levels/level_delete.php';
 
@@ -59,7 +60,13 @@ try {
     // fetch level data
     $row = level_select($pdo, $level_id);
     if ($row->user_id !== $user_id) {
-        throw new Exception('This is not your level');
+        throw new Exception('This is not your level.');
+    }
+
+    // check to see if this is a campaign level
+    $campaign_loc = campaign_level_select_by_id($pdo, $level_id);
+    if (!empty($campaign_loc)) {
+        throw new Exception('Your level could not be deleted because it is featured in a campaign.');
     }
 
     // save this file to the backup system


### PR DESCRIPTION
Before deleting a level, the server will check to see if the level is in a Campaign. If it is, it won't let the user delete the level.

This has happened before. While it's not a common thing (it's only happened about 1-5 times in PR2's history), I think it's probably best to have this check to save you the trouble of having to restore it if it happens. Just in case; especially with new Campaign levels every month from Campaign of the Month!

(I also can't test this without making tons of dummy levels on my localhost, so just take a gander and make sure everything looks up to par.)

Also, please run this query on the database:

```mysql
UPDATE `pr2_levels`
  SET `live` = "1"
  WHERE `level_id` = 1442589;
```

EDIT: To be clear, this protects against a level being deleted via the `delete_level.php` script, meaning the creator cannot delete the level. The reason I didn't add this to the mods' `remove_level.php` is that `remove_level.php` only unpublishes the level, and the script that fills the Campaign ignores whether or not the level is published.