### PR TITLE
Small fixes/additions

### DIFF
--- a/http_server/fns/pages/admin/contests/add_prize_fns.php
+++ b/http_server/fns/pages/admin/contests/add_prize_fns.php
@@ -88,6 +88,7 @@ function add_contest_prize($pdo, $admin, $contest)
     );
 
     // output the page
+    output_header("Add Contest Prize", true, true);
     echo "Great success! <b>$html_contest_name</b> is now able to award the $full_part_name.";
     echo "<br><br>";
     echo "<a href='add_prize.php?contest_id=$contest_id'>&lt;- Add Another Prize</a><br>";

--- a/http_server/www/contests/award_prize.php
+++ b/http_server/www/contests/award_prize.php
@@ -13,6 +13,7 @@ require_once QUERIES_DIR . '/messages/message_insert.php';
 $ip = get_ip();
 $contest_id = (int) find('contest_id', 0);
 $action = find('action', 'form');
+$header = false;
 
 try {
     // rate limiting
@@ -66,6 +67,7 @@ try {
     }
 
     // header
+    $header = true;
     output_header('Award Prize', $is_mod, $is_admin);
 
     // get prizes info for this contest
@@ -305,6 +307,7 @@ try {
         // output the page
         echo "<br>All operations completed! The results can be seen above.";
         echo "<br><br>";
+        echo "<a href='award_prize.php?contest_id=$contest_id'>&lt;- Award Another Prize</a><br>";
         echo "<a href='view_winners.php?contest_id=$contest_id'>&lt;- View Winners</a><br>";
         echo "<a href='contests.php'>&lt;- All Contests</a>";
     } // unknown handler
@@ -314,7 +317,9 @@ try {
 
     output_footer();
 } catch (Exception $e) {
-    output_header("Error", $is_mod, $is_admin);
+    if ($header === false) {
+        output_header("Error", $is_mod, $is_admin);
+    }
     $error = $e->getMessage();
     echo "Error: $error<br><br><a href='javascript:history.back()'><- Go Back</a>";
     output_footer();

--- a/http_server/www/contests/award_prize.php
+++ b/http_server/www/contests/award_prize.php
@@ -9,6 +9,7 @@ require_once QUERIES_DIR . '/contest_prizes/contest_prizes_select_by_contest.php
 require_once QUERIES_DIR . '/contest_winners/throttle_awards.php';
 require_once QUERIES_DIR . '/contest_winners/contest_winner_insert.php';
 require_once QUERIES_DIR . '/messages/message_insert.php';
+require_once QUERIES_DIR . '/pr2/pr2_insert.php'; // if pr2 data doesn't exist
 
 $ip = get_ip();
 $contest_id = (int) find('contest_id', 0);

--- a/http_server/www/login.php
+++ b/http_server/www/login.php
@@ -124,7 +124,7 @@ try {
         }
         
         // see if they're trying to log into a guest
-        if ($user->power == 0 && $guest_login === false) {
+        if ($user->power == 0 && $guest_login === false && $token_login === false) {
             throw new Exception('Direct logins to guest accounts are not permitted. '.
                                'To play as a guest, click the "Play as Guest" button on the main menu.');
         }

--- a/multiplayer_server/Player.php
+++ b/multiplayer_server/Player.php
@@ -16,7 +16,6 @@ class Player
     public $exp_points;
     public $start_exp_today;
     public $exp_today;
-    public $last_exp_time;
     public $group;
     public $guest;
 
@@ -58,6 +57,7 @@ class Player
     public $url = '';
     public $version = '0.0';
 
+    public $last_exp_time;
     public $last_action = 0;
     public $chat_count = 0;
     public $chat_time = 0;
@@ -545,6 +545,9 @@ class Player
                         $pefeetc = $player->feet_color_2;
                         $pdomain = $player->domain;
                         $pversion = $player->version;
+                        $plaction = $player->socket->last_action;
+                        $plaction = format_duration(time() - $plaction) . " ago ($plaction)";
+                        $plexp = format_duration(time() - $player->last_exp_time) . " ago ($player->last_exp_time)";
                         if ($player->temp_mod === true) {
                             $ptemp = 'yes';
                         } else {
@@ -562,10 +565,12 @@ class Player
                             ."ip: $pip<br>"
                             ."name: $pname | user_id: $puid<br>"
                             ."status: $pstatus<br>"
+                            ."last_action: $plaction<br>"
                             ."group: $pgroup | temp_mod: $ptemp | server_owner: $pso<br>"
                             ."guild_id: $pguild<br>"
                             ."active_rank: $parank | rank (no rt): $prank | rt_used: $prtused | rt_avail: $prtavail<br>"
                             ."exp_today: $pexp2day | exp_points: $pexppoints<br>"
+                            ."last_exp_time: $plexp<br>"
                             ."speed: $pspeed | acceleration: $paccel | jumping: $pjump<br>"
                             ."hat: $phat | head: $phead | body: $pbody | feet: $pfeet<br>"
                             ."hat_color: $phatc | hat_color_2: $pehatc<br>"
@@ -1541,7 +1546,6 @@ class Player
         $this->exp_points = null;
         $this->start_exp_today = null;
         $this->exp_today = null;
-        $this->last_exp_time = null;
         $this->group = null;
         $this->guest = null;
         $this->hat_color = null;
@@ -1573,6 +1577,7 @@ class Player
         $this->rt_available = null;
         $this->url = null;
         $this->version = null;
+        $this->last_exp_time = null;
         $this->last_action = null;
         $this->chat_count = null;
         $this->chat_time = null;

--- a/multiplayer_server/Player.php
+++ b/multiplayer_server/Player.php
@@ -16,6 +16,7 @@ class Player
     public $exp_points;
     public $start_exp_today;
     public $exp_today;
+    public $last_exp_time;
     public $group;
     public $guest;
 
@@ -150,6 +151,7 @@ class Player
         $this->rt_used = (int) $login->rt_used;
         $this->rt_available = (int) $login->rt_available;
         $this->exp_today = (int) $this->start_exp_today = (int) $login->exp_today;
+        $this->last_exp_time = time();
         $this->status = $login->status;
 
         $socket->player = $this;
@@ -1539,6 +1541,7 @@ class Player
         $this->exp_points = null;
         $this->start_exp_today = null;
         $this->exp_today = null;
+        $this->last_exp_time = null;
         $this->group = null;
         $this->guest = null;
         $this->hat_color = null;

--- a/multiplayer_server/Player.php
+++ b/multiplayer_server/Player.php
@@ -741,7 +741,7 @@ class Player
                     } elseif (HappyHour::isActive() && $this->hh_warned) {
                         HappyHour::deactivate();
                         $player_room->sendChat('systemChat`' .
-                            htmlspecialchars($this->name) .
+                            userify($this, $this->name) .
                             ' just ended the current Happy Hour.');
                     } else {
                         $this->write('systemChat`There isn\'t an active Happy Hour right now.');

--- a/multiplayer_server/fns/vault_fns.php
+++ b/multiplayer_server/fns/vault_fns.php
@@ -16,23 +16,38 @@ function process_unlock_super_booster($socket, $data)
 // unlock a temporary perk
 function process_unlock_perk($socket, $data)
 {
+    global $player_array;
+
     if ($socket->process == true) {
         list( $slug, $user_id, $guild_id, $user_name ) = explode('`', $data);
 
         start_perk($slug, $user_id, $guild_id);
+        $player = id_to_player($user_id, false);
+        $display_name = userify($player, $user_name);
 
         if ($guild_id != 0) {
             if ($slug == \pr2\multi\Perks::GUILD_FRED) {
-                send_to_guild($guild_id, "systemChat`$user_name unlocked Fred mode for your guild!");
+                send_to_guild($guild_id, "systemChat`$display_name unlocked Fred mode for your guild!");
             }
             if ($slug == \pr2\multi\Perks::GUILD_GHOST) {
-                send_to_guild($guild_id, "systemChat`$user_name unlocked Ghost mode for your guild!");
+                send_to_guild($guild_id, "systemChat`$display_name unlocked Ghost mode for your guild!");
             }
             if ($slug == \pr2\multi\Perks::GUILD_ARTIFACT) {
-                send_to_guild($guild_id, "systemChat`$user_name unlocked Artifact mode for your guild!");
+                send_to_guild($guild_id, "systemChat`$display_name unlocked Artifact mode for your guild!");
             }
             if ($slug == \pr2\multi\Perks::HAPPY_HOUR) {
-                sendToAll_players("systemChat`$user_name just triggered a Happy Hour!");
+                global $chat_room_array;
+                if (isset($chat_room_array['main'])) {
+                    $main = $chat_room_array['main'];
+                    $main->sendChat("systemChat`$display_name just triggered a Happy Hour!", -1);
+                    foreach ($player_array as $player) {
+                        if (isset($player->chat_room) && $player->chat_room != $main) {
+                            $player->write("systemChat`$display_name just triggered a Happy Hour!");
+                        }
+                    }
+                } else {
+                    sendToAll_players("systemChat`$display_name just triggered a Happy Hour!");
+                }
             }
         }
 

--- a/multiplayer_server/rooms/Game.php
+++ b/multiplayer_server/rooms/Game.php
@@ -645,7 +645,7 @@ class Game extends Room
             }
 
             // disconnects anyone trying to earn exp too quick
-            if ($player->last_exp_time >= (time() - 3)) {
+            if ($player->last_exp_time >= (time() - 2)) {
                 $player->socket->write("message`Botting is a no-no. :(");
                 $player->remove();
             }

--- a/multiplayer_server/rooms/Game.php
+++ b/multiplayer_server/rooms/Game.php
@@ -644,7 +644,14 @@ class Game extends Room
                 $tot_exp_gain = 0;
             }
 
-            // increment exp and maybe save
+            // disconnects anyone trying to earn exp too quick
+            if ($player->last_exp_time >= (time() - 3)) {
+                $player->socket->write("message`Botting is a no-no. :(");
+                $player->remove();
+            }
+
+            // log/increment exp and maybe save
+            $player->last_exp_time = time();
             $player->incExp($tot_exp_gain);
             $player->maybeSave();
         } else {


### PR DESCRIPTION
Fixes:
 - Fix guest login not working when returning from the level editor (#530)
 - Stop 2 headers from appearing on an error in `/contests/award_prize.php`
 - Add a header on success in `/admin/contests/add_prize.php`
 - Fix fatal error when awarding prizes to accounts that don't have entries in `pr2`, `epic_upgrades`, or both* (a DB query is needed to complete this. see below)

Additions:
 - Add a link to add another prize on success in `/contests/award_prize.php`
 - Userify the HH deactivated message (socket server)
 - Userify the perk activated messages (socket server)
 - Add a tiny botting check, as discussed in [this comment](https://github.com/jacob-grahn/platform-racing-2-server/issues/285#issuecomment-417982001) (socket server)



*= run this query on the database (changes the default value for part fields in `epic_upgrades` from `NULL` to empty):

```mysql
ALTER TABLE `epic_upgrades` 
  CHANGE `epic_hats` `epic_hats` VARCHAR(110) CHARACTER SET latin1 COLLATE 
  latin1_swedish_ci NOT NULL DEFAULT '', 
  CHANGE `epic_heads` `epic_heads` VARCHAR(110) CHARACTER SET latin1 COLLATE 
  latin1_swedish_ci NOT NULL DEFAULT '', 
  CHANGE `epic_bodies` `epic_bodies` VARCHAR(110) CHARACTER SET latin1 COLLATE 
  latin1_swedish_ci NOT NULL DEFAULT '', 
  CHANGE `epic_feet` `epic_feet` VARCHAR(110) CHARACTER SET latin1 COLLATE 
  latin1_swedish_ci NOT NULL DEFAULT ''; 
```

Also, it would be great if you could run this query as well:

```mysql
ALTER TABLE `recent_logins`
ADD INDEX(`user_id`);
```

This should significantly decrease database load when calling data from that table.