### PR TITLE
htmlspecialchars -> ENT_QUOTES, various small edits

### DIFF
--- a/common/queries/messages/message_send_welcome.php
+++ b/common/queries/messages/message_send_welcome.php
@@ -3,7 +3,7 @@
 function message_send_welcome($pdo, $name, $user_id)
 {
     // compose a welcome pm
-    $safe_name = htmlspecialchars($name);
+    $safe_name = htmlspecialchars($name, ENT_QUOTES);
     $welcome_message = "Welcome to Platform Racing 2, $safe_name!\n\n"
         ."<a href='https://grahn.io' target='_blank'><u><font color='#0000FF'>"
         ."Click here</font></u></a> to read about the latest Platform Racing news on my blog.\n\n"

--- a/common/queries/part_awards/ensure_awards.php
+++ b/common/queries/part_awards/ensure_awards.php
@@ -2,16 +2,12 @@
 
 function ensure_awards($pdo)
 {
-    // select all records, they get cleared out weekly or somesuch
+    // select all records
     $awards = part_awards_select_list($pdo);
 
     // give users their awards
     foreach ($awards as $row) {
-        if ($row->part == 0) {
-            $part = '*';
-        } else {
-            $part = $row->part;
-        }
+        $part = $row->part == 0 ? '*' : $row->part;
         $type = $row->type;
         $user_id = $row->user_id;
         try {
@@ -22,6 +18,6 @@ function ensure_awards($pdo)
         }
     }
 
-    // delete older records
+    // delete records older than a week
     part_awards_delete_old($pdo);
 }

--- a/common/queries/part_awards/part_awards_select_by_user.php
+++ b/common/queries/part_awards/part_awards_select_by_user.php
@@ -1,0 +1,18 @@
+<?php
+
+function part_awards_select_by_user($pdo, $user_id)
+{
+    $stmt = $pdo->prepare('
+        SELECT type, part
+          FROM part_awards
+         WHERE user_id = :user_id
+    ');
+    $stmt->bindValue(':user_id', $user_id, PDO::PARAM_INT);
+    $result = $stmt->execute();
+
+    if ($result === false) {
+        throw new Exception('Could not select user\'s pending awards.');
+    }
+
+    return $stmt->fetchAll(PDO::FETCH_OBJ);
+}

--- a/common/queries/staff/admin/users_select_by_ip_expanded.php
+++ b/common/queries/staff/admin/users_select_by_ip_expanded.php
@@ -29,7 +29,7 @@ function users_select_by_ip_expanded($pdo, $search_ip, $start = 0, $count = 25)
     $users = $stmt->fetchAll(PDO::FETCH_OBJ);
 
     if (empty($users)) {
-        $search_ip = htmlspecialchars($search_ip);
+        $search_ip = htmlspecialchars($search_ip, ENT_QUOTES);
         throw new Exception("Could not find any users associated for that IP "
             ."address ($search_ip) with those search parameters.");
     }

--- a/http_server/fns/cron/fah_fns.php
+++ b/http_server/fns/cron/fah_fns.php
@@ -86,7 +86,7 @@ function fah_fetch_stats()
 // validate, determine, and award fah prizes
 function fah_award_prizes($pdo, $name, $score, $prize_array)
 {
-    $safe_name = htmlspecialchars($name);
+    $safe_name = htmlspecialchars($name, ENT_QUOTES);
     $lower_name = strtolower($name);
     
     try {
@@ -178,7 +178,7 @@ function fah_award_prizes($pdo, $name, $score, $prize_array)
         output("Finished $safe_name.");
     } catch (Exception $e) {
         $error = $e->getMessage();
-        $safe_error = htmlspecialchars($error);
+        $safe_error = htmlspecialchars($error, ENT_QUOTES);
         output($safe_error);
     }
 }
@@ -186,7 +186,7 @@ function fah_award_prizes($pdo, $name, $score, $prize_array)
 // award tokens
 function fah_award_token($pdo, $user_id, $name, $score, $column, $available_tokens)
 {
-    $safe_name = htmlspecialchars($name);
+    $safe_name = htmlspecialchars($name, ENT_QUOTES);
     $token_num = $column['token'];
     $column = "r$token_num";
     
@@ -212,14 +212,14 @@ function fah_award_token($pdo, $user_id, $name, $score, $column, $available_toke
         // finalize it (send message, mark as awarded in folding_at_home)
         fah_finalize_award($pdo, $user_id, $name, $column);
     } catch (Exception $e) {
-        output(htmlspecialchars($e->getMessage()));
+        output(htmlspecialchars($e->getMessage(), ENT_QUOTES));
     }
 }
 
 // award hats
 function fah_award_hat($pdo, $user_id, $name, $score, $hat)
 {
-    $safe_name = htmlspecialchars($name);
+    $safe_name = htmlspecialchars($name, ENT_QUOTES);
     $column = $hat . '_hat';
     
     try {
@@ -247,7 +247,7 @@ function fah_award_hat($pdo, $user_id, $name, $score, $hat)
         // finalize it (send message, mark as awarded in folding_at_home)
         fah_finalize_award($pdo, $user_id, $name, $column);
     } catch (Exception $e) {
-        output(htmlspecialchars($e->getMessage()));
+        output(htmlspecialchars($e->getMessage(), ENT_QUOTES));
     }
 }
 
@@ -266,7 +266,7 @@ function fah_finalize_award($pdo, $user_id, $name, $prize_code)
                 );
     
     // compose a PM
-    $safe_name = htmlspecialchars($name);
+    $safe_name = htmlspecialchars($name, ENT_QUOTES);
     $prize_str = $prizes[$prize_code][0];
     $min_score = $prizes[$prize_code][1];
     $message = "Dear $safe_name,\n\n"

--- a/http_server/fns/data_fns.php
+++ b/http_server/fns/data_fns.php
@@ -311,12 +311,12 @@ function format_level_list($levels)
     foreach ($levels as $row) {
         $level_id = $row->level_id;
         $version = $row->version;
-        $title = urlencode(htmlspecialchars($row->title));
+        $title = urlencode(htmlspecialchars($row->title, ENT_QUOTES));
         $rating = round($row->rating, 2);
         $play_count = $row->play_count;
         $min_level = $row->min_level;
-        $note = urlencode(htmlspecialchars($row->note));
-        $user_name = urlencode(htmlspecialchars($row->name));
+        $note = urlencode(htmlspecialchars($row->note, ENT_QUOTES));
+        $user_name = urlencode(htmlspecialchars($row->name, ENT_QUOTES));
         $group = $row->power;
         $live = $row->live;
         $pass = isset($row->pass);

--- a/http_server/fns/data_fns.php
+++ b/http_server/fns/data_fns.php
@@ -26,6 +26,46 @@ function add_item(&$arr, $item)
     }
 }
 
+// awards prizes to a user for various reasons on login
+// TO-DO: Add pending contest prizes to this, then move fn to query_fns.php
+function award_special_parts($stats, $hat_array, $head_array, $body_array, $feet_array, $group)
+{
+    // get current date for holiday parts check
+    $date = date('F j');
+
+    // heart set (valentine)
+    if ($date === 'February 13' || $date === 'February 14') {
+        $stats->head = add_item($head_array, 38) ? 38 : $stats->head;
+        $stats->body = add_item($body_array, 38) ? 38 : $stats->body;
+        $stats->feet = add_item($feet_array, 38) ? 38 : $stats->feet;
+    }
+
+    // bunny set (easter)
+    $easter = date('F j', easter_date(date('Y')));
+    if ($date === $easter || date('F j', time() + 86400) === $easter) {
+        $stats->head = add_item($head_array, 39) ? 39 : $stats->head;
+        $stats->body = add_item($body_array, 39) ? 39 : $stats->body;
+        $stats->feet = add_item($feet_array, 39) ? 39 : $stats->feet;
+    }
+
+    // santa set (christmas)
+    if ($date === 'December 24' || $date === 'December 25') {
+        $stats->hat = add_item($hat_array, 7) ? 7 : $stats->hat;
+        $stats->head = add_item($head_array, 34) ? 34 : $stats->head;
+        $stats->body = add_item($body_array, 34) ? 34 : $stats->body;
+        $stats->feet = add_item($feet_array, 34) ? 34 : $stats->feet;
+    }
+
+    // party hat (new year)
+    if ($date === 'December 31' || $date === 'January 1') {
+        $stats->hat = add_item($hat_array, 8) ? 8 : $stats->hat;
+    }
+
+    // mod crown check
+    $stats->hat = $group >= 2 ? (add_item($hat_array, 6) ? 6 : $stats->hat) : $stats->hat;
+
+    return $stats;
+}
 
 // tries to find a variable in various request arrays; uses default if not found
 function find($str, $default = null, $cookie = true)
@@ -367,7 +407,7 @@ function filter_swears($str)
     $str = str_replace('bitch', $bitchArray[array_rand($bitchArray)], $str);
     $str = str_replace('cunt', $bitchArray[array_rand($bitchArray)], $str);
 
-    return( $str );
+    return $str;
 }
 
 
@@ -388,5 +428,5 @@ function rate_limit($key, $interval, $max, $error = 'Slow down a bit, yo.')
     $count++;
     apcu_store($key, $count, $interval);
 
-    return($count);
+    return $count;
 }

--- a/http_server/fns/data_fns.php
+++ b/http_server/fns/data_fns.php
@@ -28,8 +28,10 @@ function add_item(&$arr, $item)
 
 // awards prizes to a user for various reasons on login
 // TO-DO: Add pending contest prizes to this, then move fn to query_fns.php
-function award_special_parts($stats, $hat_array, $head_array, $body_array, $feet_array, $group)
+function award_special_parts($stats, $group)
 {
+    global $hat_array, $head_array, $body_array, $feet_array;
+
     // get current date for holiday parts check
     $date = date('F j');
 
@@ -61,7 +63,7 @@ function award_special_parts($stats, $hat_array, $head_array, $body_array, $feet
         $stats->hat = add_item($hat_array, 8) ? 8 : $stats->hat;
     }
 
-    // mod crown check
+    // crown for mods
     $stats->hat = $group >= 2 ? (add_item($hat_array, 6) ? 6 : $stats->hat) : $stats->hat;
 
     return $stats;

--- a/http_server/fns/pages/admin/contests/add_prize_fns.php
+++ b/http_server/fns/pages/admin/contests/add_prize_fns.php
@@ -12,7 +12,8 @@ function output_form($contest)
 
     echo '<form action="add_prize.php" method="post">';
 
-    echo 'Add Contest Prize for <b>'.htmlspecialchars($contest->contest_name).'</b><br><br>';
+    $html_contest_name = htmlspecialchars($contest->contest_name, ENT_QUOTES);
+    echo "Add Contest Prize for <b>$html_contest_name</b><br><br>";
 
     $part_type_sel = "<select name='part_type'>
                         <option value='' selected='selected'>Choose a type...</option>
@@ -42,7 +43,7 @@ function add_contest_prize($pdo, $admin, $contest)
     $contest_id = (int) $contest->contest_id;
     $part_type = find('part_type');
     $part_id = (int) find('part_id');
-    $html_contest_name = htmlspecialchars($contest->contest_name);
+    $html_contest_name = htmlspecialchars($contest->contest_name, ENT_QUOTES);
 
     // validate the prize and get a nice stdClass back
     $prize = validate_prize($part_type, $part_id);

--- a/http_server/fns/pages/admin/contests/edit_contest_fns.php
+++ b/http_server/fns/pages/admin/contests/edit_contest_fns.php
@@ -9,25 +9,31 @@ function output_form($contest)
 
     echo "Edit Contest<br><br>";
 
-    echo "Contest Name:
-        <input type='text' name='contest_name' maxlength='100' value='".htmlspecialchars($contest->contest_name)."'>
+    $contest_id = (int) $contest->contest_id;
+    $name = htmlspecialchars($contest->contest_name, ENT_QUOTES);
+    $desc = htmlspecialchars($contest->description, ENT_QUOTES);
+    $url = htmlspecialchars($contest->url, ENT_QUOTES);
+    $host_id = (int) $contest->user_id;
+    $awarding = htmlspecialchars($contest->awarding, ENT_QUOTES);
+    $max_awards = (int) $contest->max_awards;
+
+    echo "Contest Name: <input type='text' name='contest_name' maxlength='100' value='$name'>
         (the name of the contest, max: 100 characters)<br>";
-    echo "Description:
-        <input type='text' name='description' maxlength='255' value='".htmlspecialchars($contest->description)."'>
+    echo "Description: <input type='text' name='description' maxlength='255' value='$desc'>
         (short description of what the contest involves, max: 255 characters)<br>";
-    echo "Contest URL: <input type='text' name='url' maxlength='255' value='".htmlspecialchars($contest->url)."'>
+    echo "Contest URL: <input type='text' name='url' maxlength='255' value='$url'>
         (link to contest homepage, max: 255 characters)<br>";
-    echo "Host User ID: <input type='text' name='host_id' maxlength='10' value='".(int) $contest->user_id."'>
+    echo "Host User ID: <input type='text' name='host_id' maxlength='10' value='$host_id'>
         (the user ID of the PR2 player that is hosting this contest, max: 10 numbers)<br>";
-    echo "Awarding: <input type='text' name='awarding' maxlength='255' value='".htmlspecialchars($contest->awarding)."'>
+    echo "Awarding: <input type='text' name='awarding' maxlength='255' value='$awarding)'>
         (summary of the prizes the contest is awarding, max: 255 characters)<br>";
-    echo "Max Awards: <input type='text' name='max_awards' maxlength='2' value='".(int) $contest->max_awards."'>
+    echo "Max Awards: <input type='text' name='max_awards' maxlength='2' value='$max_awards'>
         (max times a contest owner can award prizes per week, suggested: 1-3, min: 1, max: 50)<br>";
     echo "Active: <input type='checkbox' name='active' $active_checked>
         (contest visible and prizes able to be awarded)<br>";
 
     echo '<input type="hidden" name="action" value="edit">';
-    echo "<input type='hidden' name='contest_id' value='".(int) $contest->contest_id."'>";
+    echo "<input type='hidden' name='contest_id' value='$contest_id'>";
 
     echo '<br>';
     echo '<input type="submit" value="Edit Contest">&nbsp;(no confirmation!)';

--- a/http_server/fns/pages/admin/contests/edit_contest_fns.php
+++ b/http_server/fns/pages/admin/contests/edit_contest_fns.php
@@ -25,7 +25,7 @@ function output_form($contest)
         (link to contest homepage, max: 255 characters)<br>";
     echo "Host User ID: <input type='text' name='host_id' maxlength='10' value='$host_id'>
         (the user ID of the PR2 player that is hosting this contest, max: 10 numbers)<br>";
-    echo "Awarding: <input type='text' name='awarding' maxlength='255' value='$awarding)'>
+    echo "Awarding: <input type='text' name='awarding' maxlength='255' value='$awarding'>
         (summary of the prizes the contest is awarding, max: 255 characters)<br>";
     echo "Max Awards: <input type='text' name='max_awards' maxlength='2' value='$max_awards'>
         (max times a contest owner can award prizes per week, suggested: 1-3, min: 1, max: 50)<br>";

--- a/http_server/fns/pages/admin/guild_deep_info_fns.php
+++ b/http_server/fns/pages/admin/guild_deep_info_fns.php
@@ -15,13 +15,14 @@ function output_object($obj, $sep = '<br/>')
     if ($obj !== false) {
         foreach ($obj as $var => $val) {
             if ($var == 'name') {
-                $safe_val = htmlspecialchars($val);
+                $safe_val = htmlspecialchars($val, ENT_QUOTES);
                 $url_val = urlencode($val);
                 $val = "<a href='player_deep_info.php?name1=$url_val'>$safe_val</a>";
                 echo "$var: $val".$sep;
             }
             if ($var != 'guild_id' && $var != 'name') {
-                echo "$var: ".htmlspecialchars($val)."$sep";
+                $safe_val = htmlspecialchars($val, ENT_QUOTES);
+                echo "$var: $safe_val$sep";
             }
         }
     }

--- a/http_server/fns/pages/admin/player_deep_info_fns.php
+++ b/http_server/fns/pages/admin/player_deep_info_fns.php
@@ -20,7 +20,7 @@ function output_object($obj, $sep = '<br/>')
     if ($obj !== false) {
         foreach ($obj as $var => $val) {
             if ($var == 'email') {
-                $safe_email = htmlspecialchars($val);
+                $safe_email = htmlspecialchars($val, ENT_QUOTES);
                 $url_email = urlencode($val);
                 $val = "<a href='search_by_email.php?email=$url_email'>$safe_email</a>";
                 echo "$var: $val $sep";
@@ -38,7 +38,8 @@ function output_object($obj, $sep = '<br/>')
                 $val = date('M j, Y g:i A', $val);
             }
             if ($var != 'user_id' && $var != 'email' && $var != 'guild') {
-                echo "$var: ".htmlspecialchars($val)."$sep";
+                $safe_val = htmlspecialchars($val, ENT_QUOTES);
+                echo "$var: $safe_val$sep";
             }
         }
         if ($sep != '<br/>') {

--- a/http_server/fns/pages/admin/set_campaign_fns.php
+++ b/http_server/fns/pages/admin/set_campaign_fns.php
@@ -17,8 +17,8 @@ function prize_check($type, $id, $err_prefix)
     $type_array = array("hat", "head", "body", "feet", "eHat", "eHead", "eBody", "eFeet");
 
     // safety first
-    $safe_type = htmlspecialchars($type);
-    $safe_id = htmlspecialchars($id);
+    $safe_type = htmlspecialchars($type, ENT_QUOTES);
+    $safe_id = htmlspecialchars($id, ENT_QUOTES);
 
     // check for a valid prize type
     if (!in_array($type, $type_array)) {

--- a/http_server/fns/pages/contests/part_vars.php
+++ b/http_server/fns/pages/contests/part_vars.php
@@ -156,7 +156,7 @@ function to_part_name($type, $id)
 
 function validate_prize($type, $id)
 {
-    $type = htmlspecialchars(strtolower($type));
+    $type = htmlspecialchars(strtolower($type), ENT_QUOTES);
     $id = (int) $id;
     $type_array = array("hat", "head", "body", "feet", "ehat", "ehead", "ebody", "efeet");
 

--- a/http_server/fns/pages/guild_search_fns.php
+++ b/http_server/fns/pages/guild_search_fns.php
@@ -56,7 +56,7 @@ function output_guild_search($guild_name = '', $guild_id = '', $mode = null)
         .'<br>';
 
     // name form
-    $html_guild_name = htmlspecialchars($guild_name);
+    $html_guild_name = htmlspecialchars($guild_name, ENT_QUOTES);
     echo "<div id='nameform' style='display:$name_display'><br>
               <form method='get'>
                   Name: <input type='text' name='name' value='$html_guild_name'>

--- a/http_server/fns/pages/player_search_fns.php
+++ b/http_server/fns/pages/player_search_fns.php
@@ -7,7 +7,7 @@ function create_ban_list($bans)
     $str = '<p><ul>';
     foreach ($bans as $row) {
         $ban_date = date("F j, Y, g:i a", $row->time);
-        $reason = htmlspecialchars($row->reason);
+        $reason = htmlspecialchars($row->reason, ENT_QUOTES);
         $ban_id = $row->ban_id;
         $str .= "<li><a href='/bans/show_record.php?ban_id=$ban_id'>$ban_date</a>: $reason";
     }
@@ -35,7 +35,7 @@ function find_user($pdo, $name)
 function output_search($name = '', $gwibble = true)
 {
     // safety first
-    $safe_name = htmlspecialchars($name);
+    $safe_name = htmlspecialchars($name, ENT_QUOTES);
 
     // gwibble output
     if ($gwibble === true) {
@@ -96,13 +96,13 @@ function output_page($pdo, $user)
     }
 
     // safety first
-    $safe_name = htmlspecialchars($user_name);
-    $safe_status = htmlspecialchars($status);
+    $safe_name = htmlspecialchars($user_name, ENT_QUOTES);
+    $safe_status = htmlspecialchars($status, ENT_QUOTES);
     if ($guild_name == '<i>none</i>') {
         $safe_guild = $guild_name;
     } else {
         $safe_guild = "<a href='/guild_search.php?name=".urlencode($guild_name)."'>"
-            . htmlspecialchars($guild_name) . "</a>";
+            . htmlspecialchars($guild_name, ENT_QUOTES) . "</a>";
     }
 
     // --- Start the Page --- \\

--- a/http_server/fns/query_fns.php
+++ b/http_server/fns/query_fns.php
@@ -2,7 +2,6 @@
 
 function pass_login($pdo, $name, $password)
 {
-
     // get their ip
     $ip = get_ip();
 
@@ -44,7 +43,6 @@ function pass_login($pdo, $name, $password)
 // login using a token
 function token_login($pdo, $use_cookie = true, $suppress_error = false)
 {
-
     $rec_token = find_no_cookie('token');
     if (isset($rec_token) && !empty($rec_token)) {
         $token = $rec_token;
@@ -230,7 +228,7 @@ function type_to_db_field($type)
     } else {
         throw new Exception('Unknown type');
     }
-    return( $field );
+    return $field;
 }
 
 
@@ -257,8 +255,7 @@ function append_to_str_array($str_arr, $val) // is this needed?
 // generates a login token
 function get_login_token($user_id)
 {
-    $token = $user_id . '-' . random_str(30);
-    return $token;
+    return $user_id . '-' . random_str(30);
 }
 
 

--- a/http_server/www/account_change_email.php
+++ b/http_server/www/account_change_email.php
@@ -96,9 +96,9 @@ try {
         changing_email_insert($pdo, $user_id, $old_email, $new_email, $code, $ip);
 
         // safety first
-        $safe_user_name = htmlspecialchars($user_name);
-        $safe_old_email = htmlspecialchars($old_email);
-        $safe_new_email = htmlspecialchars($new_email);
+        $safe_user_name = htmlspecialchars($user_name, ENT_QUOTES);
+        $safe_old_email = htmlspecialchars($old_email, ENT_QUOTES);
+        $safe_new_email = htmlspecialchars($new_email, ENT_QUOTES);
 
         // send a confirmation email
         $from = 'Fred the Giant Cactus <contact@jiggmin.com>';
@@ -119,7 +119,7 @@ try {
             .'address will still be active.';
     }
 } catch (Exception $e) {
-    $ret->error = $e->getMessage();
+    $ret->error = htmlspecialchars($e->getMessage(), ENT_QUOTES);
 } finally {
     echo json_encode($ret);
 }

--- a/http_server/www/account_change_email.php
+++ b/http_server/www/account_change_email.php
@@ -73,6 +73,11 @@ try {
         throw new Exception("Guests don't even really have accounts...");
     }
 
+    // sanity check: is this already their email?
+    if ($old_email === $new_email) {
+        throw new Exception("That's already the email on your account!");
+    }
+
     // rate limiting
     rate_limit('change-email-'.$user_id, 86400, 2, 'Your email can be changed a maximum of two times per day.');
     rate_limit('change-email-'.$ip, 86400, 2, 'Your email can be changed a maximum of two times per day.');

--- a/http_server/www/account_confirm_email_change.php
+++ b/http_server/www/account_confirm_email_change.php
@@ -43,7 +43,7 @@ try {
     echo "Great success! Your email address has been changed from $safe_old_email to $safe_new_email.";
 } catch (Exception $e) {
     output_header('Confirm Email Change');
-    $error = htmlspecialchars($e->getMessage(), ENT_QUOTES)
+    $error = htmlspecialchars($e->getMessage(), ENT_QUOTES);
     echo "Error: $error";
 } finally {
     output_footer();

--- a/http_server/www/account_confirm_email_change.php
+++ b/http_server/www/account_confirm_email_change.php
@@ -35,15 +35,16 @@ try {
     user_update_email($pdo, $user_id, $old_email, $new_email);
 
     // make some variables
-    $safe_old_email = htmlspecialchars($old_email);
-    $safe_new_email = htmlspecialchars($new_email);
+    $safe_old_email = htmlspecialchars($old_email, ENT_QUOTES);
+    $safe_new_email = htmlspecialchars($new_email, ENT_QUOTES);
 
     // tell it to the world
     output_header('Confirm Email Change');
     echo "Great success! Your email address has been changed from $safe_old_email to $safe_new_email.";
 } catch (Exception $e) {
     output_header('Confirm Email Change');
-    echo $e->getMessage();
+    $error = htmlspecialchars($e->getMessage(), ENT_QUOTES)
+    echo "Error: $error";
 } finally {
     output_footer();
 }

--- a/http_server/www/add_friend.php
+++ b/http_server/www/add_friend.php
@@ -6,7 +6,7 @@ require_once HTTP_FNS . '/all_fns.php';
 require_once QUERIES_DIR . '/friends/friend_insert.php';
 
 $friend_name = $_POST['target_name'];
-$safe_friend_name = htmlspecialchars($friend_name);
+$safe_friend_name = htmlspecialchars($friend_name, ENT_QUOTES);
 $ip = get_ip();
 
 try {
@@ -43,6 +43,6 @@ try {
     // tell it to the world
     echo "message=$safe_friend_name has been added to your friends list!";
 } catch (Exception $e) {
-    $error = $e->getMessage();
+    $error = htmlspecialchars($e->getMessage(), ENT_QUOTES);
     echo "error=$error";
 }

--- a/http_server/www/admin/admin_log.php
+++ b/http_server/www/admin/admin_log.php
@@ -12,34 +12,34 @@ try {
     rate_limit('admin-log-'.$ip, 60, 10, 'Wait a bit before searching again.');
     rate_limit('admin-log-'.$ip, 5, 2);
     
-    //connect
+    // connect
     $pdo = pdo_connect();
 
-    //make sure you're an admin
+    // make sure you're an admin
     $admin = check_moderator($pdo, false, 3);
 
-    //get actions for this page
+    // get actions for this page
     $actions = admin_actions_select($pdo, $start, $count);
 
     // output header
     output_header('Admin Action Log', true, true);
 
-    //navigation
+    // navigation
     output_pagination($start, $count);
     echo '<p>---</p>';
 
-
-    //output actions
+    // output actions
     foreach ($actions as $row) {
-        echo "<p><span class='date'>$row->time</span> -- ".htmlspecialchars($row->message)."</p>";
+        $message = htmlspecialchars($row->message, ENT_QUOTES);
+        echo "<p><span class='date'>$row->time</span> -- $message</p>";
     }
-
 
     echo '<p>---</p>';
     output_pagination($start, $count);
 } catch (Exception $e) {
     output_header('Error');
-    echo 'Error: '.$e->getMessage();
+    $error = htmlspecialchars($e->getMessage(), ENT_QUOTES);
+    echo "Error: ";
 } finally {
     output_footer();
 }

--- a/http_server/www/admin/contests/remove_prize.php
+++ b/http_server/www/admin/contests/remove_prize.php
@@ -47,7 +47,7 @@ try {
 
     // form
     if ($action === 'form') {
-        $html_contest_name = htmlspecialchars($contest->contest_name);
+        $html_contest_name = htmlspecialchars($contest->contest_name, ENT_QUOTES);
         echo "Remove Prizes from <b>$html_contest_name</b>"
             ."<br><br>"
             ."<form method='post'>";
@@ -94,7 +94,7 @@ try {
         // make some variables
         $contest_id = (int) $contest->contest_id;
         $contest_name = $contest->contest_name;
-        $html_contest_name = htmlspecialchars($contest_name);
+        $html_contest_name = htmlspecialchars($contest_name, ENT_QUOTES);
         $removed = 0; // count the number of prizes removed
 
         // determine if we're removing these prizes
@@ -109,7 +109,7 @@ try {
             }
 
             // some names of things
-            $prize_name = htmlspecialchars(default_post("prize_name_$prize_id", ''));
+            $prize_name = htmlspecialchars(default_post("prize_name_$prize_id", ''), ENT_QUOTES);
 
             // do it
             $operation = contest_prize_delete($pdo, $prize_id, true);

--- a/http_server/www/admin/guild_deep_info.php
+++ b/http_server/www/admin/guild_deep_info.php
@@ -7,17 +7,17 @@ require_once QUERIES_DIR . '/guilds/guild_select.php';
 require_once QUERIES_DIR . '/guilds/guild_select_members.php';
 require_once QUERIES_DIR . '/guild_transfers/guild_transfers_select_by_guild.php';
 
-$guild_id = find('guild_id', 0);
+$guild_id = (int) find('guild_id', 0);
 
 try {
     // rate limiting
     rate_limit('guild-deep-info-'.$ip, 60, 10, 'Wait a bit before searching again.');
     rate_limit('guild-deep-info-'.$ip, 5, 2);
 
-    //connect
+    // connect
     $pdo = pdo_connect();
 
-    //make sure you're an admin
+    // make sure you're an admin
     $mod = check_moderator($pdo, false, 3);
 
     if ($guild_id == 0) {
@@ -26,11 +26,10 @@ try {
 
     output_header('Guild Deep Info', true, true);
 
-
     echo '<form name="input" action="" method="get">';
-    echo 'Guild ID: <input type="text" name="guild_id" value="'.htmlspecialchars($guild_id).'">&nbsp;';
+    echo "Guild ID: <input type='text' name='guild_id' value='$guild_id'>&nbsp;";
     echo '<input type="submit" value="Submit"><br>';
-    if ($guild_id != '') {
+    if (!is_empty($guild_id, false)) {
         try {
             $guild = guild_select($pdo, $guild_id);
             $owner_transfers = guild_transfers_select_by_guild($pdo, $guild_id, true);
@@ -38,16 +37,19 @@ try {
             output_object($guild);
             output_objects($owner_transfers);
             output_objects($members);
-            echo '<a href="update_guild.php?guild_id='.$guild->guild_id.'">edit</a><br><br><br>';
+            $guild_id = (int) $guild->guild_id;
+            echo "<a href='update_guild.php?guild_id=$guild_id'>edit</a><br><br><br>";
         } catch (Exception $e) {
-            echo "<i>Error: ".$e->getMessage()."</i><br><br>";
+            $error = htmlspecialchars($e->getMessage, ENT_QUOTES);
+            echo "<i>Error: $error</i><br><br>";
         }
     }
 
     echo '</form>';
-    output_footer();
 } catch (Exception $e) {
     output_header('Error');
-    echo 'Error: ' . $e->getMessage();
+    $error = htmlspecialchars($e->getMessage(), ENT_QUOTES);
+    echo "Error: $error";
+} finally {
     output_footer();
 }

--- a/http_server/www/admin/ip_deep_search.php
+++ b/http_server/www/admin/ip_deep_search.php
@@ -7,7 +7,7 @@ require_once QUERIES_DIR . '/staff/admin/users_count_from_ip_expanded.php';
 require_once QUERIES_DIR . '/staff/admin/users_select_by_ip_expanded.php';
 
 $ip = default_get('ip', '');
-$html_ip = htmlspecialchars($ip);
+$html_ip = htmlspecialchars($ip, ENT_QUOTES);
 $start = (int) default_get('start', 0);
 $count = (int) default_get('count', 25);
 $group_colors = ['7e7f7f', '047b7b', '1c369f', '870a6f'];
@@ -62,8 +62,8 @@ try {
 
         if ($user_count > 0 && count($users) > 0) {
             echo '<p>---</p>';
-            $html_ip = htmlspecialchars(urlencode($ip));
-            output_pagination($start, $count, "&ip=$html_ip", $is_end);
+            $url_ip = urlencode($ip);
+            output_pagination($start, $count, "&ip=$url_ip", $is_end);
         }
 
         foreach ($users as $user) {
@@ -84,16 +84,16 @@ try {
 
         // output page navigation
         if ($user_count > 0 && count($users) > 0) {
-            $html_ip = htmlspecialchars(urlencode($ip));
-            output_pagination($start, $count, "&ip=$html_ip", $is_end);
+            $url_ip = urlencode($ip);
+            output_pagination($start, $count, "&ip=$url_ip", $is_end);
         }
     } else {
         output_search('', false);
     }
     output_footer();
 } catch (Exception $e) {
-    $message = $e->getMessage();
+    $error = htmlspecialchars($e->getMessage(), ENT_QUOTES);
     output_header('Error');
-    echo "Error: $message";
+    echo "Error: $error";
     output_footer();
 }

--- a/http_server/www/admin/player_deep_info.php
+++ b/http_server/www/admin/player_deep_info.php
@@ -35,7 +35,8 @@ try {
     echo '<form name="input" action="" method="get">';
     foreach (range(1, 9) as $i) {
         $name = ${"name$i"};
-        echo '<input type="text" name="name'.$i.'" value="'.htmlspecialchars($name).'"><br>';
+        $safe_name = htmlspecialchars($name, ENT_QUOTES);
+        echo "<input type='text' name='name$i' value='$safe_name'><br>";
 
         if ($name != '') {
             try {
@@ -46,7 +47,8 @@ try {
                 $folding = folding_select_by_user_id($pdo, $user->user_id, true);
                 $changing_emails = changing_emails_select_by_user($pdo, $user->user_id, true);
                 $logins = recent_logins_select($pdo, $user->user_id, true);
-                echo "user_id: $user->user_id <br/>";
+                $user_id = (int) $user->user_id;
+                echo "user_id: $user_id <br/>";
                 output_object($user);
                 output_object($pr2);
                 output_object($epic);
@@ -54,11 +56,12 @@ try {
                 output_object_keys($folding);
                 output_objects($changing_emails);
                 output_objects($logins, true, $user);
-                echo '<a href="update_account.php?id='.$user->user_id.'">edit</a>'
-                    .' | <a href="//pr2hub.com/mod/ban.php?user_id='.$user->user_id.'&force_ip=">ban</a>'
+                echo "<a href='update_account.php?id='$user_id'>edit</a>"
+                    ." | <a href='//pr2hub.com/mod/ban.php?user_id=$user_id&force_ip='>ban</a>"
                     .'<br><br><br>';
             } catch (Exception $e) {
-                echo "<i>Error: ".$e->getMessage()."</i><br><br>";
+                $error = htmlspecialchars($error, ENT_QUOTES);
+                echo "<i>Error: $error</i><br><br>";
             }
         }
     }
@@ -66,7 +69,8 @@ try {
     echo '</form>';
 } catch (Exception $e) {
     output_header('Error');
-    echo 'Error: ' . $e->getMessage();
+    $error = htmlspecialchars($e->getMessage(), ENT_QUOTES);
+    echo "Error: $error";
 } finally {
     output_footer();
 }

--- a/http_server/www/admin/player_deep_logins.php
+++ b/http_server/www/admin/player_deep_logins.php
@@ -54,7 +54,7 @@ try {
         }
 
         // safety first
-        $safe_name = htmlspecialchars($name);
+        $safe_name = htmlspecialchars($name, ENT_QUOTES);
 
         // show the search form
         output_search($safe_name);
@@ -83,9 +83,9 @@ try {
         // only gonna get here if there were results
         foreach ($logins as $row) {
             // make nice variables for our data
-            $ip = htmlspecialchars($row->ip); // ip
-            $country = htmlspecialchars($row->country); // country code
-            $date = htmlspecialchars($row->date); // date
+            $ip = htmlspecialchars($row->ip, ENT_QUOTES); // ip
+            $country = htmlspecialchars($row->country, ENT_QUOTES); // country code
+            $date = htmlspecialchars($row->date, ENT_QUOTES); // date
 
             // display the data
             echo "IP: $ip | Country Code: $country | Date: $date<br>";

--- a/http_server/www/admin/search_by_email.php
+++ b/http_server/www/admin/search_by_email.php
@@ -31,7 +31,7 @@ try {
         $users = users_select_by_email($pdo, $email);
 
         // protect the user
-        $disp_email = htmlspecialchars($email);
+        $disp_email = htmlspecialchars($email, ENT_QUOTES);
 
         // show the search form
         output_search($disp_email);
@@ -49,7 +49,7 @@ try {
         foreach ($users as $row) {
             // make nice variables for our data
             $url_name = urlencode($row->name); // url encode the name
-            $safe_name = htmlspecialchars($row->name); // html friendly name
+            $safe_name = htmlspecialchars($row->name, ENT_QUOTES); // html friendly name
             $safe_name = str_replace(' ', '&nbsp;', $safe_name); // multiple spaces in name
             $group = (int) $row->power; // power
             $group_color = $group_colors[$group]; // group color
@@ -69,8 +69,8 @@ try {
     }
     output_footer();
 } catch (Exception $e) {
-    $message = $e->getMessage();
+    $error = htmlspecialchars($e->getMessage(), ENT_QUOTES);
     output_header('Error');
-    echo "Error: $message";
+    echo "Error: $error";
     output_footer();
 }

--- a/http_server/www/admin/set_campaign.php
+++ b/http_server/www/admin/set_campaign.php
@@ -40,7 +40,8 @@ try {
     }
 } catch (Exception $e) {
     output_header('Error');
-    echo 'Error: ' . $e->getMessage();
+    $error = htmlspecialchars($e->getMessage(), ENT_QUOTES);
+    echo "Error: $error";
 } finally {
     output_footer();
 }

--- a/http_server/www/admin/update_account.php
+++ b/http_server/www/admin/update_account.php
@@ -46,9 +46,9 @@ try {
         echo "user_id: $user->user_id <br>---<br>";
 
 
-        echo 'Name: <input type="text" size="" name="name" value="'.htmlspecialchars($user->name).'"><br>';
-        echo 'Email: <input type="text" name="email" value="'.htmlspecialchars($user->email).'"><br>';
-        echo 'Guild: <input type="text" name="guild" value="'.htmlspecialchars($user->guild).'"><br>';
+        echo 'Name: <input type="text" size="" name="name" value="'.htmlspecialchars($user->name, ENT_QUOTES).'"><br>';
+        echo 'Email: <input type="text" name="email" value="'.htmlspecialchars($user->email, ENT_QUOTES).'"><br>';
+        echo 'Guild: <input type="text" name="guild" value="'.htmlspecialchars($user->guild, ENT_QUOTES).'"><br>';
         if ($pr2 !== false) {
             echo 'Hats: <input type="text" size="100" name="hats" value="'.$pr2->hat_array.'"><br>';
             echo 'Heads: <input type="text" size="100" name="heads" value="'.$pr2->head_array.'"><br>';
@@ -156,7 +156,7 @@ try {
         if (strtolower($user->name) != strtolower($user_name)) {
             $id_exists = name_to_id($pdo, $user_name, true);
             if ($id_exists != false) {
-                $safe_name = htmlspecialchars($user_name);
+                $safe_name = htmlspecialchars($user_name, ENT_QUOTES);
                 throw new Exception("There is already a user with the name \"$safe_name\" (ID #$id_exists).");
             }
         }

--- a/http_server/www/admin/update_account.php
+++ b/http_server/www/admin/update_account.php
@@ -43,27 +43,32 @@ try {
         $user = user_select($pdo, $user_id);
         $pr2 = pr2_select($pdo, $user_id, true);
         $epic = epic_upgrades_select($pdo, $user_id, true);
-        echo "user_id: $user->user_id <br>---<br>";
 
+        $user_id = (int) $user->user_id;
+        $name = htmlspecialchars($user->name, ENT_QUOTES);
+        $email = htmlspecialchars($user->email, ENT_QUOTES);
+        $guild = htmlspecialchars($user->guild, ENT_QUOTES);
 
-        echo 'Name: <input type="text" size="" name="name" value="'.htmlspecialchars($user->name, ENT_QUOTES).'"><br>';
-        echo 'Email: <input type="text" name="email" value="'.htmlspecialchars($user->email, ENT_QUOTES).'"><br>';
-        echo 'Guild: <input type="text" name="guild" value="'.htmlspecialchars($user->guild, ENT_QUOTES).'"><br>';
+        echo "user_id: $user_id";
+        echo "<br>---<br>";
+        echo "Name: <input type='text' name='name' value='$name'><br>";
+        echo "Email: <input type='text' name='email' value='$email'><br>";
+        echo "Guild: <input type='text' name='guild' value='$guild'><br>";
         if ($pr2 !== false) {
-            echo 'Hats: <input type="text" size="100" name="hats" value="'.$pr2->hat_array.'"><br>';
-            echo 'Heads: <input type="text" size="100" name="heads" value="'.$pr2->head_array.'"><br>';
-            echo 'Bodies: <input type="text" size="100" name="bodies" value="'.$pr2->body_array.'"><br>';
-            echo 'Feet: <input type="text" size="100" name="feet" value="'.$pr2->feet_array.'"><br>';
+            echo "Hats: <input type='text' size='100' name='hats' value='$pr2->hat_array'><br>";
+            echo "Heads: <input type=text' size='100' name='heads' value='$pr2->head_array'><br>";
+            echo "Bodies: <input type='text' size='100' name='bodies' value='$pr2->body_array'><br>";
+            echo "Feet: <input type='text' size='100' name='feet' value='$pr2->feet_array'><br>";
         }
         if ($epic !== false) {
-            echo 'Epic Hats: <input type="text" size="100" name="eHats" value="'.$epic->epic_hats.'"><br>';
-            echo 'Epic Heads: <input type="text" size="100" name="eHeads" value="'.$epic->epic_heads.'"><br>';
-            echo 'Epic Bodies: <input type="text" size="100" name="eBodies" value="'.$epic->epic_bodies.'"><br>';
-            echo 'Epic Feet: <input type="text" size="100" name="eFeet" value="'.$epic->epic_feet.'"><br>';
+            echo "Epic Hats: <input type='text' size='100' name='eHats' value='$epic->epic_hats'><br>";
+            echo "Epic Heads: <input type='text' size='100' name='eHeads' value='$epic->epic_heads'><br>";
+            echo "Epic Bodies: <input type='text' size='100' name='eBodies' value='$epic->epic_bodies'><br>";
+            echo "Epic Feet: <input type='text' size='100' name='eFeet' value='$epic->epic_feet'><br>";
         }
         echo 'Description of Changes: <input type="text" size="100" name="account_changes"><br>';
         echo '<input type="hidden" name="action" value="update">';
-        echo '<input type="hidden" name="id" value="'.$user->user_id.'">';
+        echo "<input type='hidden' name='id' value='$user_id'>";
 
         echo '<br/>';
         echo '<input type="submit" value="Submit">&nbsp;(no confirmation!)';

--- a/http_server/www/admin/update_guild.php
+++ b/http_server/www/admin/update_guild.php
@@ -42,17 +42,19 @@ try {
         $guild = guild_select($pdo, $guild_id);
         echo "guild_id: $guild->guild_id <br>---<br>";
 
+        $guild_name = htmlspecialchars($guild->guild_name, ENT_QUOTES);
+        $guild_owner = (int) $guild->owner_id;
+        $guild_prose = htmlspecialchars($guild->note, ENT_QUOTES);
+        $guild_id = (int) $guild->guild_id;
 
-        echo 'Guild Name: <input type="text" size="" name="guild_name" value="'
-            .htmlspecialchars($guild->guild_name).'"><br>';
-        echo 'Guild Owner: <input type="text" size"" name="owner_id" value="'
-            .htmlspecialchars($guild->owner_id).'"><br>';
-        echo 'Prose: <textarea rows="4" name="note">'.htmlspecialchars($guild->note).'</textarea><br>';
+        echo "Guild Name: <input type='text' size='' name='guild_name' value='$guild_name)'><br>";
+        echo "Guild Owner: <input type='text' size='' name='owner_id' value='$guild_owner'><br>";
+        echo "Prose: <textarea rows='4' name='note'>$guild_prose</textarea><br>";
         echo 'Delete Emblem? <input type="checkbox" name="delete_emblem"><br>';
         echo 'Recount Members? <input type="checkbox" name="recount_members"><br>';
         echo 'Description of Changes: <input type="text" size="100" name="guild_changes"><br>';
         echo '<input type="hidden" name="action" value="update">';
-        echo '<input type="hidden" name="guild_id_submit" value="'.$guild->guild_id.'">';
+        echo "<input type='hidden' name='guild_id_submit' value='$guild_id'>";
 
         echo '<br/>';
         echo '<input type="submit" value="Submit">&nbsp;(no confirmation!)';
@@ -153,7 +155,7 @@ try {
     if ($header === false) {
         output_header("Error");
     }
-    $error = $e->getMessage();
+    $error = htmlspecialchars($e->getMessage(), ENT_QUOTES);
     echo "Error: $error<br><br><a href='javascript:history.back()'><- Go Back</a>";
     output_footer();
 }

--- a/http_server/www/admin/update_guild.php
+++ b/http_server/www/admin/update_guild.php
@@ -47,7 +47,7 @@ try {
         $guild_prose = htmlspecialchars($guild->note, ENT_QUOTES);
         $guild_id = (int) $guild->guild_id;
 
-        echo "Guild Name: <input type='text' size='' name='guild_name' value='$guild_name)'><br>";
+        echo "Guild Name: <input type='text' size='' name='guild_name' value='$guild_name'><br>";
         echo "Guild Owner: <input type='text' size='' name='owner_id' value='$guild_owner'><br>";
         echo "Prose: <textarea rows='4' name='note'>$guild_prose</textarea><br>";
         echo 'Delete Emblem? <input type="checkbox" name="delete_emblem"><br>';

--- a/http_server/www/backups/backups.php
+++ b/http_server/www/backups/backups.php
@@ -98,9 +98,10 @@ try {
         }
 
         // success
+        $safe_title = htmlspecialchars($title, ENT_QUOTES);
         echo $desc;
         echo '<p>---</p>';
-        echo "<p><b>".htmlspecialchars($title)." v$version</b> restored successfully!</p>";
+        echo "<p><b>$safe_title v$version</b> restored successfully!</p>";
     } else {
         echo $desc;
     }
@@ -111,14 +112,15 @@ try {
     $backups = level_backups_select($pdo, $user_id);
     if (!empty($backups)) {
         foreach ($backups as $row) {
-            echo "<p>$row->date: <b>".htmlspecialchars($row->title)
-                ."</b> v$row->version <a href='?action=restore&backup_id=$row->backup_id'>restore</a></p>";
+            $title = htmlspecialchars($row->title, ENT_QUOTES);
+            echo "<p>$row->date: <b>$title</b> v$row->version "
+                ."(<a href='?action=restore&backup_id=$row->backup_id'>restore</a>)</p>";
         }
     } else {
         echo "<center>You haven't modified or deleted any levels in the past 30 days.</center>";
     }
 } catch (Exception $e) {
-    $error = $e->getMessage();
+    $error = htmlspecialchars($e->getMessage(), ENT_QUOTES);
     output_header("Level Backups");
     echo "Error: $error";
 } finally {

--- a/http_server/www/ban_user.php
+++ b/http_server/www/ban_user.php
@@ -179,11 +179,11 @@ try {
         if ($banned_user_id == 0) {
             echo "message=Guest [$banned_ip] has been banned for $duration seconds.";
         } else {
-            $disp_name = htmlspecialchars($banned_name);
+            $disp_name = htmlspecialchars($banned_name, ENT_QUOTES);
             echo "message=$disp_name has been banned for $duration seconds.";
         }
     }
 } catch (Exception $e) {
-    $error = $e->getMessage();
+    $error = htmlspecialchars($e->getMessage(), ENT_QUOTES);
     echo "error=$error";
 }

--- a/http_server/www/bans/bans.php
+++ b/http_server/www/bans/bans.php
@@ -44,8 +44,8 @@ try {
         $banned_user_id = $row->banned_user_id;
         $time = $row->time;
         $expire_time = $row->expire_time;
-        $reason = $row->reason;
-        $mod_name = $row->mod_name;
+        $reason = htmlspecialchars($row->reason, ENT_QUOTES);
+        $mod_name = htmlspecialchars($row->mod_name, ENT_QUOTES);
         $banned_name = $row->banned_name;
         $ip_ban = $row->ip_ban;
         $account_ban = $row->account_ban;
@@ -64,21 +64,20 @@ try {
             $display_name .= "[$banned_ip]";
         }
 
-        $reason = htmlspecialchars($reason);
-        $f_duration = format_duration($duration);
+        $display_name = htmlspecialchars($display_name, ENT_QUOTES);
+        $f_dur = format_duration($duration);
 
-        echo "<p>$formatted_time
-    			<a href='show_record.php?ban_id=$ban_id'>
-    			".htmlspecialchars($mod_name)." banned ".htmlspecialchars($display_name)." for $f_duration.</a><br/>
-    			Reason: ".htmlspecialchars($reason)."
-    			</p>";
+        echo "<p>"
+            ."$formatted_time <a href='show_record.php?ban_id=$ban_id'>$mod_name banned $display_name for $f_dur.</a>"
+    		."<br/>Reason: $reason"
+    		."</p>";
     }
 
     echo '<p>---</p>';
     output_pagination($start, $count);
     output_footer();
 } catch (Exception $e) {
-    $error = $e->getMessage();
+    $error = htmlspecialchars($e->getMessage(), ENT_QUOTES);
     output_header('Error');
     echo "Error: $error";
     output_footer();

--- a/http_server/www/bans/bans.php
+++ b/http_server/www/bans/bans.php
@@ -69,8 +69,8 @@ try {
 
         echo "<p>"
             ."$formatted_time <a href='show_record.php?ban_id=$ban_id'>$mod_name banned $display_name for $f_dur.</a>"
-    		."<br/>Reason: $reason"
-    		."</p>";
+            ."<br/>Reason: $reason"
+            ."</p>";
     }
 
     echo '<p>---</p>';

--- a/http_server/www/bans/show_record.php
+++ b/http_server/www/bans/show_record.php
@@ -60,13 +60,13 @@ try {
         $display_name .= "[$banned_ip]";
     }
 
-    $html_lifted_by = htmlspecialchars($lifted_by);
-    $html_lifted_reason = htmlspecialchars($lifted_reason);
-    $html_mod_name = htmlspecialchars($mod_name);
-    $html_banned_name = htmlspecialchars($display_name);
-    $html_reason = htmlspecialchars($reason);
-    $html_record = str_replace("\r", '<br/>', htmlspecialchars($record));
-    $html_notes = str_replace("\n", '<br>', htmlspecialchars($notes));
+    $html_lifted_by = htmlspecialchars($lifted_by, ENT_QUOTES);
+    $html_lifted_reason = htmlspecialchars($lifted_reason, ENT_QUOTES);
+    $html_mod_name = htmlspecialchars($mod_name, ENT_QUOTES);
+    $html_banned_name = htmlspecialchars($display_name, ENT_QUOTES);
+    $html_reason = htmlspecialchars($reason, ENT_QUOTES);
+    $html_record = str_replace("\r", '<br/>', htmlspecialchars($record, ENT_QUOTES));
+    $html_notes = str_replace("\n", '<br>', htmlspecialchars($notes, ENT_QUOTES));
 
 
     if ($lifted == 1) {

--- a/http_server/www/bans/view_priors.php
+++ b/http_server/www/bans/view_priors.php
@@ -29,7 +29,7 @@ try {
     // give some more info on the current ban in effect if there is one
     if ($row !== false) {
         $ban_id = $row->ban_id;
-        $reason = htmlspecialchars($row->reason);
+        $reason = htmlspecialchars($row->reason, ENT_QUOTES);
         $ban_end_date = date("F j, Y, g:i a", $row->expire_time);
         if ($row->ip_ban == 1 && $row->account_ban == 1 && $row->banned_name == $user_name) {
             $ban_type = 'account and IP are';
@@ -66,8 +66,8 @@ try {
         ."<p>Your IP has been banned $ip_ban_count $ip_lang.</p> $ip_ban_list"
         .'<p>Priors expire one year after the ban\'s expire date.</p>';
 } catch (Exception $e) {
-    $safe_error = htmlspecialchars($e->getMessage());
-    echo "<br /><i>Error: $safe_error</i>";
+    $error = htmlspecialchars($e->getMessage(), ENT_QUOTES);
+    echo "<br /><i>Error: $error</i>";
 } finally {
     output_footer();
 }

--- a/http_server/www/confirm_guild_transfer.php
+++ b/http_server/www/confirm_guild_transfer.php
@@ -38,12 +38,12 @@ try {
     guild_update($pdo, $guild_id, $guild->guild_name, $guild->emblem, $guild->note, $new_owner_id);
 
     // tell the world
-    $safe_guild_name = htmlspecialchars($guild->guild_name);
-    $safe_new_owner = htmlspecialchars(id_to_name($pdo, $new_owner_id));
+    $safe_guild_name = htmlspecialchars($guild->guild_name, ENT_QUOTES);
+    $safe_new_owner = htmlspecialchars(id_to_name($pdo, $new_owner_id), ENT_QUOTES);
     echo "Great success! The new owner of $safe_guild_name is $safe_new_owner. Long live $safe_guild_name!";
 } catch (Exception $e) {
-    $message = $e->getMessage();
-    echo "Error: $message";
+    $error = htmlspecialchars($e->getMessage(), ENT_QUOTES);
+    echo "Error: $error";
 } finally {
     output_footer();
 }

--- a/http_server/www/contests/award_prize.php
+++ b/http_server/www/contests/award_prize.php
@@ -49,7 +49,7 @@ try {
 
     // sanity check: is this user the contest owner, admin, or mod?
     if ($is_admin === false && $is_mod === false && $user_id !== $host_id) {
-        $html_contest_name = htmlspecialchars($contest->contest_name);
+        $html_contest_name = htmlspecialchars($contest->contest_name, ENT_QUOTES);
         throw new Exception("You don't own $html_contest_name.");
     }
 
@@ -81,7 +81,7 @@ try {
 
     // form
     if ($action === 'form') {
-        $html_contest_name = htmlspecialchars($contest->contest_name);
+        $html_contest_name = htmlspecialchars($contest->contest_name, ENT_QUOTES);
         $max_awards = (int) $contest->max_awards;
         $recent_awards = (int) throttle_awards($pdo, $contest->contest_id, $contest->user_id);
         $lang = ['sets','times'];
@@ -174,7 +174,7 @@ try {
         $winner_id = (int) $winner_id;
 
         // safety first
-        $html_winner_name = htmlspecialchars($winner_name);
+        $html_winner_name = htmlspecialchars($winner_name, ENT_QUOTES);
 
         // check if the player has the part already
         $prizes_to_award = array();

--- a/http_server/www/contests/contests.php
+++ b/http_server/www/contests/contests.php
@@ -70,12 +70,12 @@ try {
         $host_color = $group_colors[(int) $host->power];
 
         // safety first
-        $html_contest_name = htmlspecialchars($contest_name);
-        $html_desc = htmlspecialchars($desc);
-        $html_awarding = htmlspecialchars($awarding);
-        $html_contest_url = htmlspecialchars($contest_url);
-        $html_host_name = htmlspecialchars($host->name);
-        $html_url_host_name = htmlspecialchars(urlencode($host->name));
+        $html_contest_name = htmlspecialchars($contest_name, ENT_QUOTES);
+        $html_desc = htmlspecialchars($desc, ENT_QUOTES);
+        $html_awarding = htmlspecialchars($awarding, ENT_QUOTES);
+        $html_contest_url = htmlspecialchars($contest_url, ENT_QUOTES);
+        $html_host_name = htmlspecialchars($host->name, ENT_QUOTES);
+        $html_url_host_name = htmlspecialchars(urlencode($host->name), ENT_QUOTES);
 
         // are they the host?
         $is_host = false;

--- a/http_server/www/contests/view_winners.php
+++ b/http_server/www/contests/view_winners.php
@@ -34,8 +34,8 @@ try {
 
     // make some variables
     $contest_id = (int) $contest->contest_id;
-    $contest_name = htmlspecialchars($contest->contest_name);
-    $contest_url = htmlspecialchars($contest->url);
+    $contest_name = htmlspecialchars($contest->contest_name, ENT_QUOTES);
+    $contest_url = htmlspecialchars($contest->url, ENT_QUOTES);
 
     // get the winners
     $winners = contest_winners_select_by_contest($pdo, $contest_id, !$is_mod);
@@ -86,23 +86,23 @@ try {
         $last_prize = end($prizes_awarded);
 
         // other variables
-        $awarder_ip = htmlspecialchars($winner->awarder_ip);
-        $comment = htmlspecialchars($winner->comment);
+        $awarder_ip = htmlspecialchars($winner->awarder_ip, ENT_QUOTES);
+        $comment = htmlspecialchars($winner->comment, ENT_QUOTES);
 
         // awarder name and color (staff)
         if ($is_mod === true) {
             $awarder_id = (int) $winner->awarded_by;
             $awarder = user_select_name_and_power($pdo, $awarder_id);
-            $awarder_html_name = htmlspecialchars($awarder->name);
-            $awarder_url = $base_url . htmlspecialchars(urlencode($awarder->name));
+            $awarder_html_name = htmlspecialchars($awarder->name, ENT_QUOTES);
+            $awarder_url = $base_url . htmlspecialchars(urlencode($awarder->name), ENT_QUOTES);
             $awarder_color = $group_colors[(int) $awarder->power];
         }
 
         // winner name and color
         $winner = user_select_name_and_power($pdo, $winner->winner_id);
         $winner_color = $group_colors[$winner->power];
-        $winner_html_name = htmlspecialchars($winner->name);
-        $winner_url = $base_url . htmlspecialchars(urlencode($winner->name));
+        $winner_html_name = htmlspecialchars($winner->name, ENT_QUOTES);
+        $winner_url = $base_url . htmlspecialchars(urlencode($winner->name), ENT_QUOTES);
 
         // start row
         echo "<tr>"
@@ -115,7 +115,7 @@ try {
             // output readable prizes
             echo "<td class='noborder'>";
             foreach ($prizes_awarded as $prize) {
-                echo htmlspecialchars($prize);
+                echo htmlspecialchars($prize, ENT_QUOTES);
                 if ($prize != $last_prize) {
                     echo ', '; // separator; don't echo after last prize
                 }
@@ -138,7 +138,7 @@ try {
     echo "<br><br><a href='contests.php'>&lt;- All Contests";
     output_footer();
 } catch (Exception $e) {
-    $error = htmlspecialchars($e->getMessage());
+    $error = htmlspecialchars($e->getMessage(), ENT_QUOTES);
     output_header("Error");
     echo "Error: $error<br><br><a href='javascript:history.back()'><- Go Back</a>";
     output_footer();

--- a/http_server/www/get_player_info_2.php
+++ b/http_server/www/get_player_info_2.php
@@ -47,7 +47,7 @@ try {
     if ($target->guild != 0) {
         try {
             $guild = guild_select($pdo, $target->guild);
-            $guild_name = htmlspecialchars($guild->guild_name);
+            $guild_name = htmlspecialchars($guild->guild_name, ENT_QUOTES);
         } catch (Exception $e) {
             $guild_name = '';
         }
@@ -105,7 +105,7 @@ try {
     }
 } catch (Exception $e) {
     $r = new stdClass();
-    $r->error = $e->getMessage();
+    $r->error = htmlspecialchars($e->getMessage(), ENT_QUOTES);
+} finally {
+    die(json_encode($r));
 }
-
-echo json_encode($r);

--- a/http_server/www/get_user_list.php
+++ b/http_server/www/get_user_list.php
@@ -19,7 +19,7 @@ try {
     $user_id = token_login($pdo);
     $power = user_select_power($pdo, $user_id);
     if ($power <= 0) {
-        $mode = htmlspecialchars($mode);
+        $mode = htmlspecialchars($mode, ENT_QUOTES);
         throw new Exception(
             "Guests can't add players to their $mode list. ".
             "To access this feature, please create your own account."
@@ -43,7 +43,7 @@ try {
     // make individual list entries
     $num = 0;
     foreach ($users as $row) {
-        $name = urlencode(htmlspecialchars($row->name));
+        $name = urlencode(htmlspecialchars($row->name, ENT_QUOTES));
         $group = $row->power;
         $status = $row->status;
         $rank = $row->rank;
@@ -73,6 +73,6 @@ try {
         $num++;
     }
 } catch (Exception $e) {
-    $error = $e->getMessage();
+    $error = htmlspecialchars($e->getMessage(), ENT_QUOTES);
     echo "error=$error";
 }

--- a/http_server/www/guild_delete.php
+++ b/http_server/www/guild_delete.php
@@ -47,7 +47,7 @@ try {
     );
 
     // safety first
-    $safe_guild_name = htmlspecialchars($guild_name);
+    $safe_guild_name = htmlspecialchars($guild_name, ENT_QUOTES);
 
     // tell the world
     $reply = new stdClass();
@@ -55,7 +55,7 @@ try {
     $reply->message = "\"$safe_guild_name\" (ID #$guild_id) was successfully deleted.";
 } catch (Exception $e) {
     $reply = new stdClass();
-    $reply->error = $e->getMessage();
+    $reply->error = htmlspecialchars($e->getMessage(), ENT_QUOTES);
 } finally {
     echo json_encode($reply);
 }

--- a/http_server/www/guild_kick.php
+++ b/http_server/www/guild_kick.php
@@ -59,14 +59,16 @@ try {
     user_update_guild($pdo, $target_id, 0);
     guild_increment_member($pdo, $guild->guild_id, -1);
 
+    $kicked_name = htmlspecialchars($target_account->name, ENT_QUOTES);
+    $guild_name = htmlspecialchars($guild->guild_name, ENT_QUOTES);
+
     // tell it to the world
     $reply = new stdClass();
     $reply->success = true;
-    $reply->message = htmlspecialchars($target_account->name)
-        .' has been kicked from '.htmlspecialchars($guild->guild_name).'.';
+    $reply->message = "$kicked_name has been kicked from $guild_name.";
 } catch (Exception $e) {
     $reply = new stdClass();
-    $reply->error = $e->getMessage();
+    $reply->error = htmlspecialchars($e->getMessage(), ENT_QUOTES);
 } finally {
     echo json_encode($reply);
 }

--- a/http_server/www/guild_search.php
+++ b/http_server/www/guild_search.php
@@ -43,7 +43,7 @@ try {
 
         // make some variables
         $guild_id = (int) $guild->guild_id;
-        $guild_name = htmlspecialchars($guild->guild_name);
+        $guild_name = htmlspecialchars($guild->guild_name, ENT_QUOTES);
         $creation_date = date('j/M/Y', strtotime($guild->creation_date));
         $active_date = date('j/M/Y', strtotime($guild->active_date));
         $emblem = $guild->emblem;
@@ -51,9 +51,9 @@ try {
         $gp_total = (int) $guild->gp_today;
         $owner_id = (int) $guild->owner_id;
         $owner = user_select_name_and_power($pdo, $owner_id);
-        $prose = htmlspecialchars($guild->note);
-        $owner_name = htmlspecialchars($owner->name);
-        $owner_url_name = htmlspecialchars(urlencode($owner->name));
+        $prose = htmlspecialchars($guild->note, ENT_QUOTES);
+        $owner_name = htmlspecialchars($owner->name, ENT_QUOTES);
+        $owner_url_name = htmlspecialchars(urlencode($owner->name), ENT_QUOTES);
         $owner_color = $group_colors[(int) $owner->power];
         $active_count = (int) guild_count_active($pdo, $guild_id);
         $members = guild_select_members($pdo, $guild_id);
@@ -96,8 +96,8 @@ try {
             // make a new row for each member
             foreach ($members as $member) {
                 $member_id = (int) $member->user_id;
-                $member_name = htmlspecialchars($member->name);
-                $member_url_name = htmlspecialchars(urlencode($member->name));
+                $member_name = htmlspecialchars($member->name, ENT_QUOTES);
+                $member_url_name = htmlspecialchars(urlencode($member->name), ENT_QUOTES);
                 $member_color = $group_colors[$member->power];
                 $member_gp_today = (int) $member->gp_today;
                 $member_gp_total = (int) $member->gp_total;
@@ -139,7 +139,7 @@ try {
         echo '</table>';
     }
 } catch (Exception $e) {
-    $safe_error = htmlspecialchars($e->getMessage());
+    $safe_error = htmlspecialchars($e->getMessage(), ENT_QUOTES);
     output_guild_search($guild_name, $guild_id);
     echo "<br><i>Error: $safe_error</i><br>";
 } finally {

--- a/http_server/www/guild_transfer.php
+++ b/http_server/www/guild_transfer.php
@@ -52,8 +52,8 @@ try {
 
     // check if the logged in user is the owner of their guild
     if ($user_id == $owner_id && $action === 'form') {
-        $safe_name = htmlspecialchars($user->name);
-        $safe_guild_name = htmlspecialchars($guild->guild_name);
+        $safe_name = htmlspecialchars($user->name, ENT_QUOTES);
+        $safe_guild_name = htmlspecialchars($guild->guild_name, ENT_QUOTES);
 
         echo "Welcome, <b>$safe_name</b>. You are currently the owner of $safe_guild_name.<br>"
             .'<br>'
@@ -79,7 +79,7 @@ try {
 
         output_footer();
     } elseif ($user_id != $owner_id && $action === 'form') {
-        $safe_guild_name = htmlspecialchars($guild->guild_name);
+        $safe_guild_name = htmlspecialchars($guild->guild_name, ENT_QUOTES);
         throw new Exception("You aren't the owner of $safe_guild_name.");
     }
 
@@ -113,7 +113,7 @@ try {
 
         // email sanity check
         if (!valid_email($email)) {
-            $safe_email = htmlspecialchars($email);
+            $safe_email = htmlspecialchars($email, ENT_QUOTES);
             throw new Exception("'$safe_email' is not a valid email address.");
         }
 
@@ -127,15 +127,15 @@ try {
         $new_id = $new_user->user_id;
 
         // make some variables from the old user
-        $safe_old_name = htmlspecialchars($old_user->name);
+        $safe_old_name = htmlspecialchars($old_user->name, ENT_QUOTES);
         $old_power = $old_user->power;
 
         // make some variables from the new user
-        $safe_new_name = htmlspecialchars($new_user->name);
+        $safe_new_name = htmlspecialchars($new_user->name, ENT_QUOTES);
         $new_power = $new_user->power;
 
         // make some variables from the guild
-        $safe_guild_name = htmlspecialchars($guild->guild_name);
+        $safe_guild_name = htmlspecialchars($guild->guild_name, ENT_QUOTES);
         $current_owner = $guild->owner_id;
 
         // sanity check: make sure guests aren't getting any funny ideas

--- a/http_server/www/guilds_top.php
+++ b/http_server/www/guilds_top.php
@@ -32,7 +32,7 @@ try {
     //--- also disable html parsing
     foreach ($guilds as $guild) {
         $guild->active_count = guild_count_active($pdo, $guild->guild_id);
-        $guild->guild_name = htmlspecialchars($guild->guild_name);
+        $guild->guild_name = htmlspecialchars($guild->guild_name, ENT_QUOTES);
     }
 
 
@@ -43,6 +43,6 @@ try {
     echo json_encode($reply);
 } catch (Exception $e) {
     $reply = new stdClass();
-    $reply->error = $e->getMessage();
+    $reply->error = htmlspecialchars($e->getMessage(), ENT_QUOTES);
     echo json_encode($reply);
 }

--- a/http_server/www/hint.php
+++ b/http_server/www/hint.php
@@ -10,8 +10,8 @@ try {
 
     // get data, make variables
     $decode = json_decode(file_get_contents("https://pr2hub.com/files/artifact_hint.txt"));
-    $safe_hint = htmlspecialchars($decode->hint);
-    $safe_finder = htmlspecialchars($decode->finder_name);
+    $safe_hint = htmlspecialchars($decode->hint, ENT_QUOTES);
+    $safe_finder = htmlspecialchars($decode->finder_name, ENT_QUOTES);
 
     output_header('Artifact Hint');
 
@@ -46,6 +46,7 @@ try {
     output_footer();
 } catch (Exception $e) {
     output_header('Error');
-    echo 'Error: ' . htmlspecialchars($e->getMessage());
+    $error = htmlspecialchars($e->getMessage(), ENT_QUOTES);
+    echo "Error: $error";
     output_footer();
 }

--- a/http_server/www/leaderboard.php
+++ b/http_server/www/leaderboard.php
@@ -56,7 +56,7 @@ try {
     foreach ($users as $user) {
         // name
         $name = $user->name;
-        $safe_name = htmlspecialchars($name);
+        $safe_name = htmlspecialchars($name, ENT_QUOTES);
         $safe_name = str_replace(" ", "&nbsp;", $safe_name);
 
         // group
@@ -88,9 +88,8 @@ try {
     output_pagination($start, $count);
     echo "</center>";
 } catch (Exception $e) {
-    $error = $e->getMessage();
-    $safe_error = htmlspecialchars($error);
-    echo "Error: $safe_error";
+    $error = htmlspecialchars($e->getMessage(), ENT_QUOTES);
+    echo "Error: $error";
 } finally {
     output_footer();
 }

--- a/http_server/www/login.php
+++ b/http_server/www/login.php
@@ -223,7 +223,7 @@ try {
     $feet_array = explode(',', $stats->feet_array);
 
     // check if parts need to be awarded
-    $stats = award_special_parts($stats, $hat_array, $head_array, $body_array, $feet_array, $group);
+    $stats = award_special_parts($stats, $group);
 
     // select their friends list
     $friends_result = friends_select($pdo, $user_id);

--- a/http_server/www/login.php
+++ b/http_server/www/login.php
@@ -11,6 +11,7 @@ require_once QUERIES_DIR . '/users/user_select_guest.php';
 require_once QUERIES_DIR . '/users/user_select.php';
 require_once QUERIES_DIR . '/users/user_update_status.php';
 require_once QUERIES_DIR . '/users/user_update_ip.php';
+//require_once QUERIES_DIR . '/part_awards/part_awards_select_by_user.php';
 require_once QUERIES_DIR . '/pr2/pr2_select.php';
 require_once QUERIES_DIR . '/epic_upgrades/epic_upgrades_select.php';
 require_once QUERIES_DIR . '/rank_tokens/rank_token_select.php';
@@ -221,62 +222,8 @@ try {
     $body_array = explode(',', $stats->body_array);
     $feet_array = explode(',', $stats->feet_array);
 
-    // give special parts based on date
-    $date = date('F d');
-
-    // santa set
-    if ($date == 'December 24' || $date == 'December 25') {
-        if (add_item($hat_array, 7)) {
-            $stats->hat = 7;
-        }
-        if (add_item($head_array, 34)) {
-            $stats->head = 34;
-        }
-        if (add_item($body_array, 34)) {
-            $stats->body = 34;
-        }
-        if (add_item($feet_array, 34)) {
-            $stats->feet = 34;
-        }
-    }
-
-    // bunny set
-    if ($date == 'April 7' || $date == 'April 8') {
-        if (add_item($head_array, 39)) {
-            $stats->head = 39;
-        }
-        if (add_item($body_array, 39)) {
-            $stats->body = 39;
-        }
-        if (add_item($feet_array, 39)) {
-            $stats->feet = 39;
-        }
-    }
-
-    // party hat
-    if ($date == 'December 31' || $date == 'January 1') {
-        if (add_item($hat_array, 8)) {
-            $stats->hat = 8;
-        }
-    }
-
-    // heart set
-    if ($date == 'February 13' || $date == 'February 14') {
-        if (add_item($head_array, 38)) {
-            $stats->head = 38;
-        }
-        if (add_item($body_array, 38)) {
-            $stats->body = 38;
-        }
-        if (add_item($feet_array, 38)) {
-            $stats->feet = 38;
-        }
-    }
-
-    // give crown hats to moderators
-    if ($group > 1) {
-        add_item($hat_array, 6);
-    }
+    // check if parts need to be awarded
+    $stats = award_special_parts($stats, $hat_array, $head_array, $body_array, $feet_array, $group);
 
     // select their friends list
     $friends_result = friends_select($pdo, $user_id);

--- a/http_server/www/mod/ip_info.php
+++ b/http_server/www/mod/ip_info.php
@@ -46,7 +46,7 @@ try {
         $html_isp = htmlspecialchars($ip_info->isp, ENT_QUOTES);
         $url_isp = htmlspecialchars(urlencode($ip_info->isp), ENT_QUOTES);
         $html_city = htmlspecialchars($ip_info->city, ENT_QUOTES);
-        $html_region = htmlspecialchars($ip_info->region, ENT_QUOTES);
+        $html_region = htmlspecialchars($ip_info->region_name, ENT_QUOTES);
         $html_country = htmlspecialchars($ip_info->country_name, ENT_QUOTES);
         $html_country_code = htmlspecialchars($ip_info->country_code, ENT_QUOTES);
 

--- a/http_server/www/mod/ip_info.php
+++ b/http_server/www/mod/ip_info.php
@@ -41,14 +41,14 @@ try {
         $ip_info = $ip_info->data->geo;
 
         // make some variables
-        $html_host = htmlspecialchars($ip_info->host);
-        $html_dns = htmlspecialchars($ip_info->dns);
-        $html_isp = htmlspecialchars($ip_info->isp);
-        $url_isp = htmlspecialchars(urlencode($ip_info->isp));
-        $html_city = htmlspecialchars($ip_info->city);
-        $html_region = htmlspecialchars($ip_info->region);
-        $html_country = htmlspecialchars($ip_info->country_name);
-        $html_country_code = htmlspecialchars($ip_info->country_code);
+        $html_host = htmlspecialchars($ip_info->host, ENT_QUOTES);
+        $html_dns = htmlspecialchars($ip_info->dns, ENT_QUOTES);
+        $html_isp = htmlspecialchars($ip_info->isp, ENT_QUOTES);
+        $url_isp = htmlspecialchars(urlencode($ip_info->isp), ENT_QUOTES);
+        $html_city = htmlspecialchars($ip_info->city, ENT_QUOTES);
+        $html_region = htmlspecialchars($ip_info->region, ENT_QUOTES);
+        $html_country = htmlspecialchars($ip_info->country_name, ENT_QUOTES);
+        $html_country_code = htmlspecialchars($ip_info->country_code, ENT_QUOTES);
 
         // make a location string out of the location data
         $html_location = '';
@@ -64,7 +64,7 @@ try {
     }
 
     // we can dance if we want to, we can leave your friends behind
-    $html_ip = htmlspecialchars($ip);
+    $html_ip = htmlspecialchars($ip, ENT_QUOTES);
 
     // header
     output_header('IP Info', true);
@@ -96,7 +96,7 @@ try {
     // give some more info on the current ban in effect if there is one
     if ($row !== false) {
         $ban_id = $row->ban_id;
-        $reason = htmlspecialchars($row->reason);
+        $reason = htmlspecialchars($row->reason, ENT_QUOTES);
         $ban_end_date = date("F j, Y, g:i a", $row->expire_time);
         $banned = "<a href='/bans/show_record.php?ban_id=$ban_id'>Yes.</a>
             This IP is banned until $ban_end_date. Reason: $reason";
@@ -128,7 +128,7 @@ try {
 
     foreach ($users as $user) {
         $user_id = (int) $user->user_id;
-        $name = htmlspecialchars($user->name);
+        $name = htmlspecialchars($user->name, ENT_QUOTES);
         $power_color = $group_colors[(int) $user->power];
         $active = date('j/M/Y', (int) $user->time);
 

--- a/http_server/www/mod/lift_ban.php
+++ b/http_server/www/mod/lift_ban.php
@@ -40,7 +40,7 @@ try {
         $user_id = $mod->user_id;
         $name = $mod->name;
         if ($reason != '') {
-            $disp_reason = "Reason: " . htmlspecialchars($reason);
+            $disp_reason = "Reason: " . htmlspecialchars($reason, ENT_QUOTES);
         } else {
             $disp_reason = "There was no reason given";
         }

--- a/http_server/www/mod/mod_log.php
+++ b/http_server/www/mod/mod_log.php
@@ -30,13 +30,14 @@ try {
 
     //output actions
     foreach ($actions as $row) {
-        echo "<p><span class='date'>$row->time</span> -- ".htmlspecialchars($row->message)."</p>";
+        $message = htmlspecialchars($row->message, ENT_QUOTES);
+        echo "<p><span class='date'>$row->time</span> -- $message</p>";
     }
 
     echo '<p>---</p>';
     output_pagination($start, $count);
 } catch (Exception $e) {
-    $error = $e->getMessage();
+    $error = htmlspecialchars($e->getMessage(), ENT_QUOTES);
     output_header("Error");
     echo "Error: $error";
 } finally {

--- a/http_server/www/mod/player_info.php
+++ b/http_server/www/mod/player_info.php
@@ -62,7 +62,7 @@ try {
     //give some more info on the current ban in effect if there is one
     if ($row !== false) {
         $ban_id = $row->ban_id;
-        $reason = htmlspecialchars($row->reason);
+        $reason = htmlspecialchars($row->reason, ENT_QUOTES);
         $ban_end_date = date("F j, Y, g:i a", $row->expire_time);
         if ($row->ip_ban == 1 && $row->account_ban == 1 && $row->banned_name == $user_name) {
             $ban_type = 'account and ip are';
@@ -114,12 +114,12 @@ try {
     }
 
     // safety first
-    $html_overridden_ip = htmlspecialchars($overridden_ip);
-    $html_ip = htmlspecialchars($ip);
-    $html_url_ip = htmlspecialchars(urlencode($ip));
+    $html_overridden_ip = htmlspecialchars($overridden_ip, ENT_QUOTES);
+    $html_ip = htmlspecialchars($ip, ENT_QUOTES);
+    $html_url_ip = htmlspecialchars(urlencode($ip), ENT_QUOTES);
 
     // output the results
-    $html_user_name = htmlspecialchars($user_name);
+    $html_user_name = htmlspecialchars($user_name, ENT_QUOTES);
     echo "<p>User ID: $user_id</p>"
         ."<p>IP: <del>$html_overridden_ip</del> <a href='ip_info.php?ip=$html_url_ip'>$html_ip</a></p>"
         ."<p>Status: $status</p>";

--- a/http_server/www/mod/reported_messages.php
+++ b/http_server/www/mod/reported_messages.php
@@ -33,15 +33,15 @@ try {
     //output the messages
     foreach ($messages as $row) {
         $formatted_time = date('M j, Y g:i A', $row->sent_time);
-        $from_name = str_replace(' ', '&nbsp;', htmlspecialchars($row->from_name));
-        $to_name = str_replace(' ', '&nbsp;', htmlspecialchars($row->to_name));
+        $from_name = str_replace(' ', '&nbsp;', htmlspecialchars($row->from_name, ENT_QUOTES));
+        $to_name = str_replace(' ', '&nbsp;', htmlspecialchars($row->to_name, ENT_QUOTES));
         $from_user_id = $row->from_user_id;
         $to_user_id = $row->to_user_id;
         $from_ip = $row->from_ip;
         $reporter_ip = $row->reporter_ip;
         $archived = $row->archived;
         $message_id = $row->message_id;
-        $html_safe_message = htmlspecialchars(filter_swears($row->message));
+        $html_safe_message = htmlspecialchars(filter_swears($row->message), ENT_QUOTES);
         $html_safe_message = str_replace("\r", '<br>', $html_safe_message);
 
         if ($archived) {

--- a/http_server/www/place_artifact.php
+++ b/http_server/www/place_artifact.php
@@ -64,7 +64,7 @@ try {
     $message = "Great success! The artifact location will be updated at the top of the next minute.";
     echo "message=$message";
 } catch (Exception $e) {
-    $error = htmlspecialchars($e->getMessage());
+    $error = htmlspecialchars($e->getMessage(), ENT_QUOTES);
     echo "error=$error";
     $message = "Error: $error";
 } finally {
@@ -96,6 +96,6 @@ try {
             echo "You're not online, so you couldn't be notified on the server.";
         }
     } catch (Exception $e) {
-        echo $e->getMessage();
+        echo htmlspecialchars($e->getMessage(), ENT_QUOTES);
     }
 }

--- a/http_server/www/player_search.php
+++ b/http_server/www/player_search.php
@@ -35,7 +35,7 @@ try {
     output_search($name);
     output_page($pdo, $user);
 } catch (Exception $e) {
-    $safe_error = htmlspecialchars($e->getMessage());
+    $safe_error = htmlspecialchars($e->getMessage(), ENT_QUOTES);
     output_search($name);
     echo "<br /><i>Error: $safe_error</i>";
 } finally {

--- a/http_server/www/remove_friend.php
+++ b/http_server/www/remove_friend.php
@@ -6,7 +6,7 @@ require_once HTTP_FNS . '/all_fns.php';
 require_once QUERIES_DIR . '/friends/friend_delete.php';
 
 $friend_name = $_POST['target_name'];
-$safe_friend_name = htmlspecialchars($friend_name);
+$safe_friend_name = htmlspecialchars($friend_name, ENT_QUOTES);
 $ip = get_ip();
 
 try {
@@ -43,6 +43,6 @@ try {
     // tell the world
     echo "message=$safe_friend_name has been removed from your friends list.";
 } catch (Exception $e) {
-    $error = $e->getMessage();
+    $error = htmlspecialchars($e->getMessage(), ENT_QUOTES);
     echo "error=$error";
 }

--- a/http_server/www/server_status.php
+++ b/http_server/www/server_status.php
@@ -34,7 +34,7 @@ try {
         // make some variables
         $happy_hour = check_value($server->happy_hour, 1, $yes, $no);
         $tournament = check_value($server->tournament, 1, $yes, $no);
-        $server_name = htmlspecialchars($server->server_name);
+        $server_name = htmlspecialchars($server->server_name, ENT_QUOTES);
         $guild_id = (int) $server->guild_id;
         $population = (int) $server->population;
         $status = $server->status;
@@ -69,7 +69,7 @@ try {
     // end table
     echo "</table>";
 } catch (Exception $e) {
-    $safe_message = htmlspecialchars($e->getMessage());
+    $safe_message = htmlspecialchars($e->getMessage(), ENT_QUOTES);
     echo "Error: $safe_message";
 } finally {
     echo "</center>";

--- a/http_server/www/staff.php
+++ b/http_server/www/staff.php
@@ -32,7 +32,7 @@ try {
 
     foreach ($staff_list as $row) {
         // make nice variables for our data
-        $safe_name = htmlspecialchars($row->name);
+        $safe_name = htmlspecialchars($row->name, ENT_QUOTES);
         $safe_name = str_replace(' ', '&nbsp;', $safe_name);
         $group = (int) $row->power;
         $group_color = $group_colors[$group];
@@ -76,7 +76,8 @@ try {
     // end the table
     echo '</table>';
 } catch (Exception $e) {
-    echo "<br><i>Error: " . htmlspecialchars($e->getMessage()) . '</i>';
+    $error = htmlspecialchars($e->getMessage(), ENT_QUOTES);
+    echo "<br><i>Error: $error</i>";
 } finally {
     echo '</center>';
     output_footer();

--- a/http_server/www/un_ignore_user.php
+++ b/http_server/www/un_ignore_user.php
@@ -40,9 +40,9 @@ try {
     ignored_delete($pdo, $user_id, $target_id);
 
     // tell the world
-    $safe_name = htmlspecialchars($target_name);
+    $safe_name = htmlspecialchars($target_name, ENT_QUOTES);
     echo "message=$safe_name has been un-ignored. You will now recieve any chat or private messages they send you.";
 } catch (Exception $e) {
-    $error = $e->getMessage();
+    $error = htmlspecialchars($e->getMessage(), ENT_QUOTES);
     echo "error=$error";
 }

--- a/multiplayer_server/Player.php
+++ b/multiplayer_server/Player.php
@@ -839,10 +839,12 @@ class Player
                     $hats_link = urlify('https://jiggmin2.com/forums/showthread.php?tid=122', 'Hats');
                     $eups_link = urlify('https://jiggmin2.com/forums/showthread.php?tid=123', 'Epic Upgrades');
                     $groups_link = urlify('https://jiggmin2.com/forums/showthread.php?tid=146', 'Groups');
+                    $fah_link = urlify('https://jiggmin2.com/forums/showthread.php?tid=19', 'Folding at Home (F@H)');
                     $this->write('systemChat`Helpful Resources:<br>'
                                 ."- $hats_link<br>"
                                 ."- $eups_link<br>"
-                                ."- $groups_link");
+                                ."- $groups_link<br>"
+                                ."- $fah_link");
                 } else {
                     $this->write('systemChat`To get a list of guides that explain different parts of PR2,'
                                 .' go to the chat tab in the lobby and type /guides.');

--- a/multiplayer_server/Player.php
+++ b/multiplayer_server/Player.php
@@ -56,7 +56,7 @@ class Player
     public $version = '0.0';
 
     public $last_exp_time;
-    public $last_action = 0;
+    public $last_user_action = 0;
     public $chat_count = 0;
     public $chat_time = 0;
 
@@ -541,7 +541,7 @@ class Player
                         $pefeetc = $player->feet_color_2;
                         $pdomain = $player->domain;
                         $pversion = $player->version;
-                        $plaction = $player->socket->last_action;
+                        $plaction = $player->socket->last_user_action;
                         $plaction = format_duration(time() - $plaction) . " ago ($plaction)";
                         $plexp = format_duration(time() - $player->last_exp_time) . " ago ($player->last_exp_time)";
                         if ($player->temp_mod === true) {
@@ -561,7 +561,7 @@ class Player
                             ."ip: $pip<br>"
                             ."name: $pname | user_id: $puid<br>"
                             ."status: $pstatus<br>"
-                            ."last_action: $plaction<br>"
+                            ."last_user_action: $plaction<br>"
                             ."group: $pgroup | temp_mod: $ptemp | server_owner: $pso<br>"
                             ."guild_id: $pguild<br>"
                             ."active_rank: $parank | rank (no rt): $prank | rt_used: $prtused | rt_avail: $prtavail<br>"

--- a/multiplayer_server/Player.php
+++ b/multiplayer_server/Player.php
@@ -921,7 +921,7 @@ class Player
                 elseif ($this->active_rank < 3 && $this->group < 2) {
                     $this->write('systemChat`Sorries, you must be rank 3 or above to chat.');
                 } // muted check (warnings, auto-warn, manual mute duration)
-                elseif ($isMuted === true && ($this->group < 2 || ($guild_id != 0 && $this->server_owner === false))) {
+                elseif ($isMuted === true) {
                     $cb_secs = (int) Mutes::remainingTime($this->name);
                     $this->write("systemChat`You have been temporarily muted from the chat. ".
                         "The mute will be lifted in $cb_secs seconds.");
@@ -1510,14 +1510,13 @@ class Player
     }
 
 
-
     public function remove()
     {
         global $player_array;
 
         unset($player_array[$this->user_id]);
 
-        //make sure the socket is nice and dead
+        // make sure the socket is nice and dead
         if (is_object($this->socket)) {
             $this->socket->player = null;
             $this->socket->close();
@@ -1525,7 +1524,7 @@ class Player
             $this->socket = null;
         }
 
-        //get out of whatever you're in
+        // get out of whatever you're in
         if (isset($this->right_room)) {
             $this->right_room->removePlayer($this);
         }
@@ -1539,81 +1538,16 @@ class Player
             $this->course_box->clearSlot($this);
         }
 
-        //save info
-        $this->status = "offline";
+        // save info
+        $this->status = 'offline';
         $this->verifyStats();
         $this->verifyParts(true);
         $this->saveInfo();
 
-        //delete
-        $this->socket = null;
-        $this->user_id = null;
-        $this->guild_id = null;
-        $this->name = null;
-        $this->rank = null;
-        $this->active_rank = null;
-        $this->exp_points = null;
-        $this->start_exp_today = null;
-        $this->exp_today = null;
-        $this->group = null;
-        $this->guest = null;
-        $this->hat_color = null;
-        $this->head_color = null;
-        $this->body_color = null;
-        $this->feet_color = null;
-        $this->hat_color_2 = null;
-        $this->head_color_2 = null;
-        $this->body_color_2 = null;
-        $this->feet_color_2 = null;
-        $this->hat = null;
-        $this->head = null;
-        $this->body = null;
-        $this->feet = null;
-        $this->hat_array = null;
-        $this->head_array = null;
-        $this->body_array = null;
-        $this->feet_array = null;
-        $this->epic_hat_array = null;
-        $this->epic_head_array = null;
-        $this->epic_body_array = null;
-        $this->epic_feet_array = null;
-        $this->speed = null;
-        $this->acceleration = null;
-        $this->jumping = null;
-        $this->friends = null;
-        $this->ignored = null;
-        $this->rt_used = null;
-        $this->rt_available = null;
-        $this->url = null;
-        $this->version = null;
-        $this->last_exp_time = null;
-        $this->last_action = null;
-        $this->chat_count = null;
-        $this->chat_time = null;
-        $this->right_room = null;
-        $this->chat_room = null;
-        $this->game_room = null;
-        $this->course_box = null;
-        $this->confirmed = null;
-        $this->slot = null;
-        $this->temp_id = null;
-        $this->pos_x = null;
-        $this->pos_y = null;
-        $this->worn_hat_array = null;
-        $this->finished_race = null;
-        $this->quit_race = null;
-        $this->domain = null;
-        $this->ip = null;
-        $this->temp_mod = null;
-        $this->server_owner = null;
-        $this->hh_warned = null;
-        $this->restart_warned = null;
-        $this->status = null;
-        $this->lives = null;
-        $this->items_used = null;
-        $this->super_booster = null;
-        $this->last_save_time = null;
-        $this->friends_array = null;
-        $this->ignored_array = null;
+        // delete
+        foreach ($this as $key => $var) {
+            $this->$key = null;
+            unset($this->$key);
+        }
     }
 }

--- a/multiplayer_server/Player.php
+++ b/multiplayer_server/Player.php
@@ -1547,7 +1547,7 @@ class Player
         // delete
         foreach ($this as $key => $var) {
             $this->$key = null;
-            unset($this->$key);
+            unset($this->$key, $key, $var);
         }
     }
 }

--- a/multiplayer_server/fns/client/moderation.php
+++ b/multiplayer_server/fns/client/moderation.php
@@ -12,7 +12,7 @@ function client_kick($socket, $data)
     $mod = $socket->getPlayer();
 
     // safety first
-    $safe_kname = htmlspecialchars($name);
+    $safe_kname = htmlspecialchars($name, ENT_QUOTES);
 
     // if the player actually has the power to do what they're trying to do, then do it
     if ($mod->group >= 2 && (@$kicked->group < 2 || ($mod->server_owner == true && $kicked != $mod))) {
@@ -74,7 +74,7 @@ function client_unkick($socket, $data)
 
     // get some info
     $mod = $socket->getPlayer();
-    $unkicked_name = htmlspecialchars($name);
+    $unkicked_name = htmlspecialchars($name, ENT_QUOTES);
 
     // if the player actually has the power to do what they're trying to do, then do it
     if (($mod->group >= 2 && $mod->temp_mod === false) || $mod->server_owner === true) {
@@ -112,7 +112,7 @@ function client_warn($socket, $data)
     $mod = $socket->getPlayer();
 
     // safety first
-    $safe_wname = htmlspecialchars($name);
+    $safe_wname = htmlspecialchars($name, ENT_QUOTES);
 
     $w_str = '';
     $time = 0;
@@ -177,7 +177,7 @@ function client_unmute($socket, $data)
 
     // get some info
     $mod = $socket->getPlayer();
-    $unmuted_name = htmlspecialchars($name);
+    $unmuted_name = htmlspecialchars($name, ENT_QUOTES);
 
     // if the player actually has the power to do what they're trying to do, then do it
     if (($mod->group >= 2 && $mod->temp_mod === false) || $mod->server_owner === true) {
@@ -205,7 +205,7 @@ function client_ban($socket, $data)
     $banned = name_to_player($banned_name);
 
     // safety first
-    $safe_reason = htmlspecialchars($reason);
+    $safe_reason = htmlspecialchars($reason, ENT_QUOTES);
 
     // set a variable that uses seconds to make friendly times
     switch ($seconds) {
@@ -267,7 +267,7 @@ function client_promote_to_moderator($socket, $data)
     $promoted = name_to_player($name);
 
     // safety first
-    $safe_pname = htmlspecialchars($name);
+    $safe_pname = htmlspecialchars($name, ENT_QUOTES);
 
     // if they're an admin and not a server owner, continue with the promotion (1st line of defense)
     if ($admin->group >= 3 && $admin->server_owner == false) {

--- a/multiplayer_server/fns/client/moderation.php
+++ b/multiplayer_server/fns/client/moderation.php
@@ -236,7 +236,7 @@ function client_ban($socket, $data)
     // instead of overwriting the $reason variable, set a new one
     $disp_reason = "Reason: $safe_reason";
     if ($reason == '') {
-        $disp_reason = 'There was no reason was given';
+        $disp_reason = 'There was no reason given';
     }
 
     // tell the world

--- a/multiplayer_server/fns/data_fns.php
+++ b/multiplayer_server/fns/data_fns.php
@@ -46,7 +46,7 @@ function userify($player, $name, $power = null)
         $link = "event:user`" . $player->group . '`' . $name;
         $url = urlify($link, $name, "#$color");
         return $url;
-    } elseif (is_null($player) && !is_null($power)) {
+    } elseif (@is_null($player->group) && !is_null($power)) {
         $color = group_color($power);
         $link = "event:user`" . $power . '`' . $name;
         $url = urlify($link, $name, "#$color");

--- a/multiplayer_server/fns/staff/demod.php
+++ b/multiplayer_server/fns/staff/demod.php
@@ -5,7 +5,7 @@ function demote_mod($user_name, $admin, $demoted_player)
     global $pdo, $server_name, $guild_owner;
 
     // safety first
-    $html_user_name = htmlspecialchars($user_name);
+    $html_user_name = htmlspecialchars($user_name, ENT_QUOTES);
 
     // if the user isn't an admin on the server, kill the function (2nd line of defense)
     if ($admin->group != 3) {
@@ -94,7 +94,7 @@ function demote_mod($user_name, $admin, $demoted_player)
             throw new Exception("$user_name isn't a moderator.");
         }
     } catch (Exception $e) {
-        $message = htmlspecialchars($e->getMessage());
+        $message = htmlspecialchars($e->getMessage(), ENT_QUOTES);
         echo "Error: $message";
         $admin->write("message`Error: $message");
         return false;

--- a/multiplayer_server/fns/staff/promote_to_moderator.php
+++ b/multiplayer_server/fns/staff/promote_to_moderator.php
@@ -5,8 +5,8 @@ function promote_to_moderator($name, $type, $admin, $promoted)
     global $pdo, $server_name;
 
     // safety first
-    $html_name = htmlspecialchars($name);
-    $html_type = htmlspecialchars($type);
+    $html_name = htmlspecialchars($name, ENT_QUOTES);
+    $html_type = htmlspecialchars($type, ENT_QUOTES);
 
     // sanity check: is the admin valid and online?
     if (!isset($admin)) {

--- a/multiplayer_server/fns/staff/server_owner.php
+++ b/multiplayer_server/fns/staff/server_owner.php
@@ -5,7 +5,7 @@ function promote_server_mod($name, $owner, $promoted)
     global $guild_owner;
 
     // safety first
-    $safe_name = htmlspecialchars($name);
+    $safe_name = htmlspecialchars($name, ENT_QUOTES);
 
     // if the user doesn't own the server, kill the function (2nd line of defense)
     if ($owner->group < 3 ||
@@ -70,7 +70,7 @@ function demote_server_mod($name, $owner, $demoted)
     global $guild_owner;
 
     // safety first
-    $safe_name = htmlspecialchars($name);
+    $safe_name = htmlspecialchars($name, ENT_QUOTES);
 
     // sanity check: does the user own the server?
     if ($owner->group < 3 || $owner->server_owner == false || $owner->user_id != $guild_owner) {

--- a/multiplayer_server/fns/utils.php
+++ b/multiplayer_server/fns/utils.php
@@ -204,7 +204,7 @@ function query_if_banned($pdo, $user_id, $ip)
 // get ban priors (for lazy mods)
 function get_priors($pdo, $mod, $name)
 {
-    $safe_name = htmlspecialchars($name);
+    $safe_name = htmlspecialchars($name, ENT_QUOTES);
 
     // sanity: make sure they're online and a staff member
     if (!isset($mod) || $mod->group < 2 || $mod->temp_mod == true || $mod->server_owner == true) {
@@ -229,12 +229,12 @@ function get_priors($pdo, $mod, $name)
 
     // make user vars
     $name = $user->name;
-    $safe_name = htmlspecialchars($name);
+    $safe_name = htmlspecialchars($name, ENT_QUOTES);
     $ip = $user->ip;
     $power = (int) $user->power;
 
     // initialize return string var
-    $url_name = htmlspecialchars(urlencode($name));
+    $url_name = htmlspecialchars(urlencode($name), ENT_QUOTES);
     $user_link = urlify("https://pr2hub.com/mod/player_info.php?name=$url_name", $safe_name, '#'.group_color($power));
     $str = "<b>Ban Data for $user_link</b><br><br>";
 
@@ -244,7 +244,7 @@ function get_priors($pdo, $mod, $name)
     $row = query_if_banned($pdo, $user_id, $ip);
     if ($row !== false) {
         $ban_id = $row->ban_id;
-        $reason = htmlspecialchars($row->reason);
+        $reason = htmlspecialchars($row->reason, ENT_QUOTES);
         $ban_end_date = date("F j, Y, g:i a", $row->expire_time);
         if ($row->ip_ban == 1 && $row->account_ban == 1 && $row->banned_name == $name) {
             $ban_type = 'account and IP are';
@@ -271,12 +271,12 @@ function get_priors($pdo, $mod, $name)
             $str .= '<li>';
             $ban_id = (int) $ban->ban_id;
             $date = date("M j, Y g:i A", $ban->time);
-            $mod_name = htmlspecialchars($ban->mod_name);
-            $url_mod_name = htmlspecialchars(urlencode($ban->mod_name));
-            $banned_name = htmlspecialchars($ban->banned_name);
-            $banned_ip = htmlspecialchars(urlencode($ban->banned_ip));
+            $mod_name = htmlspecialchars($ban->mod_name, ENT_QUOTES);
+            $url_mod_name = htmlspecialchars(urlencode($ban->mod_name), ENT_QUOTES);
+            $banned_name = htmlspecialchars($ban->banned_name, ENT_QUOTES);
+            $banned_ip = htmlspecialchars(urlencode($ban->banned_ip), ENT_QUOTES);
             $duration = format_duration($ban->expire_time - $ban->time);
-            $reason = htmlspecialchars($ban->reason);
+            $reason = htmlspecialchars($ban->reason, ENT_QUOTES);
             $lifted = (bool) $ban->lifted;
             $acc_ban = (bool) $ban->account_ban;
             $ip_ban = (bool) $ban->ip_ban;
@@ -299,8 +299,8 @@ function get_priors($pdo, $mod, $name)
 
             // check if lifted
             if ($lifted === true) {
-                $lifted_reason = htmlspecialchars($ban->lifted_reason);
-                $lifted_by = htmlspecialchars($ban->lifted_by);
+                $lifted_reason = htmlspecialchars($ban->lifted_reason, ENT_QUOTES);
+                $lifted_by = htmlspecialchars($ban->lifted_by, ENT_QUOTES);
                 $lifted_date = '';
                 $at_loc = strrpos($lifted_reason, '@');
                 if ($at_loc !== false) {
@@ -342,12 +342,12 @@ function get_priors($pdo, $mod, $name)
             $str .= '<li>';
             $ban_id = (int) $ban->ban_id;
             $date = date("M j, Y g:i A", $ban->time);
-            $mod_name = htmlspecialchars($ban->mod_name);
-            $url_mod_name = htmlspecialchars(urlencode($ban->mod_name));
-            $banned_name = htmlspecialchars($ban->banned_name);
-            $banned_ip = htmlspecialchars(urlencode($ban->banned_ip));
+            $mod_name = htmlspecialchars($ban->mod_name, ENT_QUOTES);
+            $url_mod_name = htmlspecialchars(urlencode($ban->mod_name), ENT_QUOTES);
+            $banned_name = htmlspecialchars($ban->banned_name, ENT_QUOTES);
+            $banned_ip = htmlspecialchars(urlencode($ban->banned_ip), ENT_QUOTES);
             $duration = format_duration($ban->expire_time - $ban->time);
-            $reason = htmlspecialchars($ban->reason);
+            $reason = htmlspecialchars($ban->reason, ENT_QUOTES);
             $lifted = (bool) $ban->lifted;
             $acc_ban = (bool) $ban->account_ban;
             $ip_ban = (bool) $ban->ip_ban;
@@ -370,8 +370,8 @@ function get_priors($pdo, $mod, $name)
 
             // check if lifted
             if ($lifted === true) {
-                $lifted_reason = htmlspecialchars($ban->lifted_reason);
-                $lifted_by = htmlspecialchars($ban->lifted_by);
+                $lifted_reason = htmlspecialchars($ban->lifted_reason, ENT_QUOTES);
+                $lifted_by = htmlspecialchars($ban->lifted_by, ENT_QUOTES);
                 $lifted_date = '';
                 $at_loc = strrpos($lifted_reason, '@');
                 if ($at_loc !== false) {

--- a/multiplayer_server/rooms/ChatRoom.php
+++ b/multiplayer_server/rooms/ChatRoom.php
@@ -14,10 +14,10 @@ class ChatRoom extends Room
 
     public function __construct($chat_room_name)
     {
-        $this->chat_room_name = htmlspecialchars($chat_room_name);
+        $this->chat_room_name = htmlspecialchars($chat_room_name, ENT_QUOTES);
 
         global $chat_room_array;
-        $chat_room_array[htmlspecialchars($chat_room_name)] = $this;
+        $chat_room_array[$this->chat_room_name] = $this;
 
         $this->chat_array = array_fill(0, $this->keep_count, '');
     }

--- a/multiplayer_server/rooms/Game.php
+++ b/multiplayer_server/rooms/Game.php
@@ -689,7 +689,7 @@ class Game extends Room
                 $names[] = "[$race_stats->name]";
             }
             $vs_names = join(' vs ', $names);
-            $html_name = htmlspecialchars($player->name);
+            $html_name = htmlspecialchars($player->name, ENT_QUOTES);
             $message = "$vs_names: // $html_name wins with a time of $str!";
             $main->sendChat("systemChat`$message", -1);
         }


### PR DESCRIPTION
`htmlspecialchars($variable, ENT_QUOTES);`

Adds the ENT_QUOTES flag to all instances of htmlspecialchars.

In addition to this change, this pull also:
 - Converts `forgot_password.php` to use the `send_email` function
 - Fixes an issue with third-party data called in `ip_info.php` not displaying properly
 - Fixes a small grammatical error in `/multiplayer_server/fns/client/moderation.php`
 - Adds F@H guide to the guides command (credit to ZXD for [this idea](https://jiggmin2.com/forums/showthread.php?tid=1284))
 - Fixes an issue with warns/kicks being able to be administered by temps to anyone
 - Fixes variable in admins' `/debug` command
 - Fixes/automates bunny set (easter) awarding code and moves operation from `login.php` to `data_fns.php`

Travis status: [![Build Status](https://travis-ci.org/bls1999/platform-racing-2-server.svg?branch=htmlspecialchars-entQuotes&c=3)](https://travis-ci.org/jacob-grahn/platform-racing-2-server/builds/458665527)