### PR TITLE
Streamline private server purchases via VoM

### DIFF
--- a/common/manage_socket/restart_server.php
+++ b/common/manage_socket/restart_server.php
@@ -1,5 +1,7 @@
 <?php
 
+error_reporting(E_ALL | E_STRICT);
+
 // env
 require_once __DIR__ . '/../../config.php';
 
@@ -8,7 +10,7 @@ require_once COMMON_DIR . '/manage_socket/socket_manage_fns.php';
 
 @$server_id = (int) $argv[1];
 
-if (isset($server_id)) {
+if (!empty($server_id)) {
     // connect
     $pdo = pdo_connect();
 
@@ -18,5 +20,5 @@ if (isset($server_id)) {
     // restart it
     restart_server(PR2_ROOT . '/pr2.php', $server->address, $server->port, $server->salt, $server->server_id);
 } else {
-    output('no server id');
+    output('No server ID was passed to restart_server.php');
 }

--- a/common/manage_socket/restart_server.php
+++ b/common/manage_socket/restart_server.php
@@ -1,7 +1,5 @@
 <?php
 
-error_reporting(E_ALL | E_STRICT);
-
 // env
 require_once __DIR__ . '/../../config.php';
 

--- a/common/manage_socket/socket_manage_fns.php
+++ b/common/manage_socket/socket_manage_fns.php
@@ -173,18 +173,16 @@ function read_pid($port)
 // kills a port
 function kill_pid($pid)
 {
-    if ($pid != null && $pid != 0 && $pid != '' && $pid != false) {
-        system("kill " . $pid, $k);
-        $pid = null;
-        if (!$k) {
-            return true;
-        } else {
+    $pid = (int) $pid;
+    if ($pid > 0) {
+        $k = `kill {$pid}`;
+        if ($k) {
             return false;
         }
     } else {
         output('There is no PID to kill.');
-        return true;
     }
+    return true;
 }
 
 
@@ -216,8 +214,8 @@ function talk_to_server($address, $port, $salt, $process_function, $receive = tr
         output("Attempting to talk to server at $address:$port...");
     }
     $reply = true;
-    $fsock = fsockopen($address, $port, $errno, $errstr, 5);
-    if ($fsock !== false) {
+    $fsock = @fsockopen($address, $port, $errno, $errstr, 5);
+    if (is_resource($fsock)) {
         if ($output === true) {
             output("Successfully connected! Writing: $process_function");
         }

--- a/common/queries/servers/server_insert.php
+++ b/common/queries/servers/server_insert.php
@@ -1,25 +1,19 @@
 <?php
 
-function server_insert($pdo, $server_name, $address, $port, $expire_timestamp, $salt, $guild_id)
+function server_insert($pdo, $expire_time, $server_name, $address, $port, $guild_id)
 {
-    $expire_date = date("Y-m-d H:i:s", $expire_timestamp);
     $stmt = $pdo->prepare('
         INSERT INTO servers
-           SET server_name = :server_name,
+           SET expire_date = FROM_UNIXTIME(:expire_time),
+               server_name = :server_name,
                address = :address,
                port = :port,
-               expire_date = :expire_date,
-               active = true,
-               salt = :salt,
-               guild_id = :guild_id,
-               population = 0,
-               staus = "down"
+               guild_id = :guild_id
     ');
+    $stmt->bindValue(':expire_time', $expire_time, PDO::PARAM_INT);
     $stmt->bindValue(':server_name', $server_name, PDO::PARAM_STR);
     $stmt->bindValue(':address', $address, PDO::PARAM_STR);
     $stmt->bindValue(':port', $port, PDO::PARAM_INT);
-    $stmt->bindValue(':expire_date', $expire_date, PDO::PARAM_STR);
-    $stmt->bindValue(':salt', $salt, PDO::PARAM_STR);
     $stmt->bindValue(':guild_id', $guild_id, PDO::PARAM_INT);
     $result = $stmt->execute();
 

--- a/common/queries/servers/server_update_expire_date.php
+++ b/common/queries/servers/server_update_expire_date.php
@@ -1,18 +1,14 @@
 <?php
 
-function server_update_expire_date($pdo, $server_id, $expire_timestamp, $server_name)
+function server_update_expire_date($pdo, $expire_time, $server_id)
 {
-    $expire_date = date("Y-m-d H:i:s", $expire_timestamp);
     $stmt = $pdo->prepare('
         UPDATE servers
-           SET expire_date = :expire_date,
-               server_name = :server_name,
-               active = 1
+           SET expire_date = FROM_UNIXTIME(:expire_time)
          WHERE server_id = :server_id
     ');
+    $stmt->bindValue(':expire_time', $expire_time, PDO::PARAM_INT);
     $stmt->bindValue(':server_id', $server_id, PDO::PARAM_INT);
-    $stmt->bindValue(':server_name', $server_name, PDO::PARAM_STR);
-    $stmt->bindValue(':expire_date', $expire_date, PDO::PARAM_STR);
     $result = $stmt->execute();
 
     if ($result === false) {

--- a/multiplayer_server/Player.php
+++ b/multiplayer_server/Player.php
@@ -606,6 +606,7 @@ class Player
                             $ip
                         );
                         output("$this->name ($this->user_id) initiated a server shutdown.");
+                        $this->write('systemChat`Restarting...');
                         restart_server();
                     }
                 } else {

--- a/multiplayer_server/Player.php
+++ b/multiplayer_server/Player.php
@@ -601,12 +601,12 @@ class Player
                         admin_action_insert(
                             $pdo,
                             $admin_id,
-                            "$admin_name restarted $server_name from $ip.",
+                            "$admin_name ($admin_id) restarted $server_name from $ip.",
                             $admin_id,
                             $ip
                         );
-                        output("$this->name initiated a server shutdown.");
-                        shutdown_server();
+                        output("$this->name ($this->user_id) initiated a server shutdown.");
+                        restart_server();
                     }
                 } else {
                     $this->write('systemChat`This command cannot be used in levels.');

--- a/multiplayer_server/fns/utils.php
+++ b/multiplayer_server/fns/utils.php
@@ -428,9 +428,12 @@ function rate_limit($key, $interval, $max, $display_error = false, $player = nul
 
 
 // graceful shutdown
-function shutdown_server($socket = null)
+function shutdown_server($socket = null, $die = true)
 {
     global $player_array, $socket;
+
+    // kill socket
+    kill_socket();
 
     // disconnect everyone
     output('Disconnecting all players...');
@@ -447,8 +450,39 @@ function shutdown_server($socket = null)
     }
 
     // socketDaemon shutdown
-    sleep(1);
-    die();
+    if ($die === true) {
+        die();
+    }
+}
+
+
+// graceful restart
+function restart_server()
+{
+    global $server_id;
+
+    // kill socket
+    kill_socket();
+
+    // disconnect everyone
+    shutdown_server(null, false);
+
+    // start new instance of server
+    $server_id = (int) $server_id; // make sure this won't do anything weird
+    echo shell_exec('php ' . COMMON_DIR . "/manage_socket/restart_server.php $server_id 1");
+    die(output("The restart was successful."));
+}
+
+
+// close socket to new connections and unbind port
+// DO NOT CALL WITHOUT SHUTDOWN_SERVER OR RESTART_SERVER
+function kill_socket()
+{
+    global $server;
+
+    output("Closing socket and unbinding port...");
+    $server->__destruct();
+    output("Socket closed.");
 }
 
 

--- a/multiplayer_server/fns/utils.php
+++ b/multiplayer_server/fns/utils.php
@@ -427,6 +427,18 @@ function rate_limit($key, $interval, $max, $display_error = false, $player = nul
 }
 
 
+// close socket to new connections and unbind port
+// DO NOT CALL WITHOUT SHUTDOWN_SERVER OR RESTART_SERVER
+function kill_socket()
+{
+    global $server;
+
+    output("Closing socket and unbinding port...");
+    $server->__destruct();
+    output("Socket closed.");
+}
+
+
 // graceful shutdown
 function shutdown_server($socket = null, $die = true)
 {
@@ -471,18 +483,6 @@ function restart_server()
     $server_id = (int) $server_id; // make sure this won't do anything weird
     echo shell_exec('php ' . COMMON_DIR . "/manage_socket/restart_server.php $server_id");
     die(output("The restart was successful."));
-}
-
-
-// close socket to new connections and unbind port
-// DO NOT CALL WITHOUT SHUTDOWN_SERVER OR RESTART_SERVER
-function kill_socket()
-{
-    global $server;
-
-    output("Closing socket and unbinding port...");
-    $server->__destruct();
-    output("Socket closed.");
 }
 
 

--- a/multiplayer_server/fns/utils.php
+++ b/multiplayer_server/fns/utils.php
@@ -469,7 +469,7 @@ function restart_server()
 
     // start new instance of server
     $server_id = (int) $server_id; // make sure this won't do anything weird
-    echo shell_exec('php ' . COMMON_DIR . "/manage_socket/restart_server.php $server_id 1");
+    echo shell_exec('php ' . COMMON_DIR . "/manage_socket/restart_server.php $server_id");
     die(output("The restart was successful."));
 }
 


### PR DESCRIPTION
In order to complete this pull request, you must run this command on the `servers` table:

```mysql
ALTER TABLE `servers`
  MODIFY `population` int(11) NOT NULL DEFAULT '0',
  MODIFY `status` varchar(10) NOT NULL DEFAULT 'down',
  MODIFY `active` tinyint(4) NOT NULL DEFAULT '1',
  MODIFY `salt` varchar(40) NOT NULL DEFAULT 'COMM_PASS', /* We could remove this; see below */
  MODIFY `guild_id` int(11) NOT NULL DEFAULT '0';
```

**Be sure to replace `COMM_PASS` with the actual server salt.** You can either do that or not even store that value in the db and just take all server salts from the `$COMM_PASS` variable in `env.php` since it never changes. If you want to go this route, go ahead and run this query and I can apply those changes in my next pull.

This pull also fixes server restarting so that `restart_server.php` and `restart_server()` actually restart the server as intended. What a concept!

Travis **staus**: [![Build Status](https://travis-ci.org/bls1999/platform-racing-2-server.svg?branch=fix-ps-vom)](https://travis-ci.org/jacob-grahn/platform-racing-2-server/builds/454793029)