### PR TITLE
Prevent IP mismatch on login

### DIFF
--- a/http_server/www/login.php
+++ b/http_server/www/login.php
@@ -77,6 +77,7 @@ try {
     $encryptor->setKey($LOGIN_KEY);
     $str_login = $encryptor->decrypt($encrypted_login, $LOGIN_IV);
     $login = json_decode($str_login);
+    $login->ip = $ip;
     $user_name = $login->user_name;
     $user_pass = $login->user_pass;
     $version2 = $login->version;

--- a/multiplayer_server/fns/process_fns.php
+++ b/multiplayer_server/fns/process_fns.php
@@ -84,6 +84,10 @@ function process_register_login($server_socket, $data)
                 $socket->write('message`Login verify failed.');
                 $socket->close();
                 $socket->onDisconnect();
+            } elseif ($login_obj->login->ip !== $socket->ip) {
+                $socket->write('message`There\'s an IP mismatch. Check your network settings.');
+                $socket->close();
+                $socket->onDisconnect();
             } elseif ($guild_id != 0 && $guild_id != $login_obj->user->guild) {
                 $socket->write('message`You are not a member of this guild.');
                 $socket->close();


### PR DESCRIPTION
Short Description: Prevents certain types proxies by forcing traffic to come from a consistent IP on all ports (80, 9160) of entry.

:star: :star2: Long Description :star2: :star:

When a user logs into PR2, their IP is passed to both the HTTP server and the socket server, but from their respective ports. The HTTP server pulls the user's IP from the connection origin on port 80, whereas the socket server pulls the user's IP from the connection origin on port 9160 (replace with your favorite socket server's port).

These should be the same under normal circumstances; however, some proxy servers only redirect traffic over port 80, which causes a mismatch between the IP addresses given to the HTTP and socket servers. This pull aims to crack down on that mismatch by checking to ensure that the IP addresses gathered from both ports match.