### PR TITLE
[URGENT] Misc. server fixes

### DIFF
--- a/common/cron/daily.php
+++ b/common/cron/daily.php
@@ -1,6 +1,7 @@
 <?php
 
 require_once GEN_HTTP_FNS;
+require_once FNS_DIR . '/cron/cron_fns.php';
 require_once QUERIES_DIR . '/changing_emails.php';
 require_once QUERIES_DIR . '/exp_today.php';
 require_once QUERIES_DIR . '/gp.php';

--- a/common/cron/daily.php
+++ b/common/cron/daily.php
@@ -1,7 +1,6 @@
 <?php
 
 require_once GEN_HTTP_FNS;
-require_once FNS_DIR . '/cron/cron_fns.php';
 require_once QUERIES_DIR . '/changing_emails.php';
 require_once QUERIES_DIR . '/exp_today.php';
 require_once QUERIES_DIR . '/gp.php';

--- a/common/cron/weekly.php
+++ b/common/cron/weekly.php
@@ -27,6 +27,7 @@ all_optimize($pdo, $DB_NAME);
 
 // deletes old accounts every four weeks
 if (date('W') % 4 === 0) {
+    require_once FNS_DIR . '/cron/cron_fns.php';
     delete_old_accounts($pdo);
 }
 

--- a/common/cron/weekly.php
+++ b/common/cron/weekly.php
@@ -28,6 +28,7 @@ all_optimize($pdo, $DB_NAME);
 // deletes old accounts every four weeks
 if (date('W') % 4 === 0) {
     require_once FNS_DIR . '/cron/cron_fns.php';
+    require_once QUERIES_DIR . '/user_delete.php';
     delete_old_accounts($pdo);
 }
 

--- a/common/multi_queries.php
+++ b/common/multi_queries.php
@@ -1,19 +1,19 @@
 <?php
 
+require_once QUERIES_DIR . '/admin_actions.php';
 require_once QUERIES_DIR . '/artifact_location.php';
 require_once QUERIES_DIR . '/artifacts_found.php';
+require_once QUERIES_DIR . '/bans.php';
 require_once QUERIES_DIR . '/campaigns.php';
 require_once QUERIES_DIR . '/epic_upgrades.php';
 require_once QUERIES_DIR . '/exp_today.php';
 require_once QUERIES_DIR . '/guilds.php';
 require_once QUERIES_DIR . '/messages.php';
+require_once QUERIES_DIR . '/mod_actions.php';
 require_once QUERIES_DIR . '/mod_power.php';
 require_once QUERIES_DIR . '/pr2.php';
 require_once QUERIES_DIR . '/purchases.php';
 require_once QUERIES_DIR . '/promotion_log.php';
 require_once QUERIES_DIR . '/rank_tokens.php';
-require_once QUERIES_DIR . '/admin_actions.php';
-require_once QUERIES_DIR . '/mod_actions.php';
 require_once QUERIES_DIR . '/servers.php';
 require_once QUERIES_DIR . '/users.php';
-require_once QUERIES_DIR . '/bans.php';

--- a/common/queries/bans.php
+++ b/common/queries/bans.php
@@ -158,6 +158,13 @@ function ban_update($pdo, $ban_id, $account_ban, $ip_ban, $expire_time, $notes)
 }
 
 
+// alias for ban_insert
+function ban_user($pdo, $ip, $uid, $mod_uid, $expire_time, $reason, $record, $name, $mod_name, $is_ip, $is_acc)
+{
+    ban_insert($pdo, $ip, $uid, $mod_uid, $expire_time, $reason, $record, $name, $mod_name, $is_ip, $is_acc);
+}
+
+
 function bans_delete_old($pdo)
 {
     $result = $pdo->exec('DELETE FROM bans WHERE expire_time < UNIX_TIMESTAMP(NOW() - INTERVAL 1 YEAR)');

--- a/common/queries/levels.php
+++ b/common/queries/levels.php
@@ -146,7 +146,7 @@ function level_select($pdo, $level_id)
 function level_unpublish($pdo, $level_id, $suppress_error = false)
 {
     $stmt = $pdo->prepare('
-        UPDATE pr2_levels
+        UPDATE levels
            SET live = 0,
                pass = NULL
          WHERE level_id = :level_id

--- a/common/queries/tokens.php
+++ b/common/queries/tokens.php
@@ -1,7 +1,7 @@
 <?php
 
 
-function token_delete($pdo, $token)
+function token_delete($pdo, $token, $ret_count = false)
 {
     $stmt = $pdo->prepare('
         DELETE FROM tokens
@@ -14,7 +14,7 @@ function token_delete($pdo, $token)
         throw new Exception('Could not delete your login token from the database.');
     }
 
-    return $result;
+    return $ret_count === true ? $stmt->rowCount() > 0 : $result;
 }
 
 

--- a/common/queries/user_delete.php
+++ b/common/queries/user_delete.php
@@ -93,9 +93,10 @@ function user_delete_from_friends($pdo, $user_id)
     $stmt = $pdo->prepare('
         DELETE FROM friends
         WHERE user_id = :user_id
-        OR friend_id = :user_id
+        OR friend_id = :friend_id
     ');
     $stmt->bindValue(':user_id', $user_id, PDO::PARAM_INT);
+    $stmt->bindValue(':friend_id', $user_id, PDO::PARAM_INT);
     $result = $stmt->execute();
 
     if ($result === false) {
@@ -142,9 +143,10 @@ function user_delete_from_ignored($pdo, $user_id)
     $stmt = $pdo->prepare('
         DELETE FROM ignored
         WHERE user_id = :user_id
-        OR ignore_id = :user_id
+        OR ignore_id = :ignore_id
     ');
     $stmt->bindValue(':user_id', $user_id, PDO::PARAM_INT);
+    $stmt->bindValue(':ignore_id', $user_id, PDO::PARAM_INT);
     $result = $stmt->execute();
 
     if ($result === false) {
@@ -190,10 +192,11 @@ function user_delete_from_messages($pdo, $user_id)
 {
     $stmt = $pdo->prepare('
         DELETE FROM messages
-        WHERE to_user_id = :user_id
-        OR from_user_id = :user_id
+        WHERE to_user_id = :to_id
+        OR from_user_id = :from_id
     ');
-    $stmt->bindValue(':user_id', $user_id, PDO::PARAM_INT);
+    $stmt->bindValue(':to_id', $user_id, PDO::PARAM_INT);
+    $stmt->bindValue(':from_id', $user_id, PDO::PARAM_INT);
     $result = $stmt->execute();
 
     if ($result === false) {
@@ -207,10 +210,11 @@ function user_delete_from_messages_reported($pdo, $user_id)
 {
     $stmt = $pdo->prepare('
         DELETE FROM messages_reported
-        WHERE to_user_id = :user_id
-        OR from_user_id = :user_id
+        WHERE to_user_id = :to_id
+        OR from_user_id = :from_id
     ');
-    $stmt->bindValue(':user_id', $user_id, PDO::PARAM_INT);
+    $stmt->bindValue(':to_id', $user_id, PDO::PARAM_INT);
+    $stmt->bindValue(':from_id', $user_id, PDO::PARAM_INT);
     $result = $stmt->execute();
 
     if ($result === false) {

--- a/common/queries/users.php
+++ b/common/queries/users.php
@@ -288,7 +288,7 @@ function user_select_guest($pdo)
 }
 
 
-function user_select_level_plays($pdo, $user_id)
+function user_select_level_plays($pdo, $user_id, $suppress_error = false)
 {
     $stmt = $pdo->prepare('
           SELECT SUM(play_count) as total_play_count
@@ -300,7 +300,10 @@ function user_select_level_plays($pdo, $user_id)
     $result = $stmt->execute();
 
     if ($result === false) {
-        throw new Exception('Could not count the number of plays for this user.');
+        if ($suppress_error === false) {
+            throw new Exception('Could not count the number of plays for this user.');
+        }
+        return 0;
     }
 
     $row = $stmt->fetch(PDO::FETCH_OBJ);

--- a/functions/common_fns.php
+++ b/functions/common_fns.php
@@ -7,8 +7,8 @@ function query_if_banned($pdo, $user_id, $ip)
     if (!function_exists('ban_select')) {
         require_once QUERIES_DIR . '/bans.php';
     }
-    $ban = (isset($user_id) && $user_id != 0) ? ban_select_active_by_user_id($pdo, $user_id) : false; // user_id
-    $ban = (!$ban && isset($ip)) ? ban_select_active_by_ip($pdo, $ip) : false; // ip if user_id isn't found
+    $ban = isset($user_id) && $user_id != 0 ? ban_select_active_by_user_id($pdo, $user_id) : false; // user_id
+    $ban = !$ban && isset($ip) ? ban_select_active_by_ip($pdo, $ip) : $ban; // ip if user_id isn't found
     return $ban;
 }
 

--- a/functions/http_fns/http_data_fns.php
+++ b/functions/http_fns/http_data_fns.php
@@ -292,7 +292,7 @@ function format_level_list($levels)
         $num++;
     }
 
-    if (!empty(str)) {
+    if (!is_empty($str)) {
         $hash = md5($str . $LEVEL_LIST_SALT);
         $str .= '&hash='.$hash;
     }

--- a/functions/multi_fns/staff/promote_to_moderator.php
+++ b/functions/multi_fns/staff/promote_to_moderator.php
@@ -22,7 +22,7 @@ function promote_to_moderator($name, $type, $admin, $promoted)
     }
 
     // if the user being promoted is an admin, kill the function
-    if ((int) $promoted->group === 3) {
+    if (isset($promoted) && (int) $promoted->group === 3) {
         $err = 'I\'m not sure what would happen if you promoted an admin to a moderator, '
             .'but it would probably make the world explode.';
         $admin->write("message`Error: $err");
@@ -104,7 +104,7 @@ function promote_to_moderator($name, $type, $admin, $promoted)
             mod_power_insert($pdo, $user_id, $max_ban, $bans_per_hour, $can_unpublish_level);
 
             // log action in admin action log
-            $a_msg = "$admin->name promoted $promoted->name to a $type moderator from $admin->ip on $server_name.";
+            $a_msg = "$admin->name promoted $user_row->name to a $type moderator from $admin->ip on $server_name.";
             admin_action_insert($pdo, $admin->user_id, $a_msg, $admin->user_id, $admin->ip);
 
             // update everyone (server, client menus)

--- a/http_server/admin/restart_servers.php
+++ b/http_server/admin/restart_servers.php
@@ -6,8 +6,8 @@ require_once QUERIES_DIR . '/admin_actions.php';
 require_once QUERIES_DIR . '/servers.php';
 
 $ip = get_ip();
-$action = find('action', 'warning');
-$token = $_POST['token'];
+$action = default_post('action', 'warning');
+$token = default_post('token');
 
 try {
     // rate limiting
@@ -18,7 +18,7 @@ try {
     $pdo = pdo_connect();
 
     // check permission
-    is_staff($pdo, token_login($pdo), false, true, 3);
+    $admin = check_moderator($pdo, null, true, 3);
 
     // output
     output_header('Restart Servers', true, true);

--- a/http_server/admin/set_campaign.php
+++ b/http_server/admin/set_campaign.php
@@ -4,7 +4,7 @@ require_once GEN_HTTP_FNS;
 require_once HTTP_FNS . '/output_fns.php';
 require_once HTTP_FNS . '/pages/admin/set_campaign_fns.php';
 require_once QUERIES_DIR . '/admin_actions.php';
-require_once QUERIES_DIR . '/campaign.php';
+require_once QUERIES_DIR . '/campaigns.php';
 
 $action = default_post('action', 'lookup');
 $message = htmlspecialchars(default_post('message', ''));

--- a/http_server/delete_level.php
+++ b/http_server/delete_level.php
@@ -4,6 +4,7 @@ header("Content-type: text/plain");
 
 require_once GEN_HTTP_FNS;
 require_once QUERIES_DIR . '/campaigns.php';
+require_once QUERIES_DIR . '/level_backups.php';
 
 $level_id = (int) default_post('level_id', 0);
 $ip = get_ip();

--- a/http_server/guild_invite.php
+++ b/http_server/guild_invite.php
@@ -3,6 +3,7 @@
 header("Content-type: text/plain");
 
 require_once GEN_HTTP_FNS;
+require_once HTTP_FNS . '/pr2/pr2_fns.php';
 require_once QUERIES_DIR . '/guild_invitations.php';
 
 $target_id = (int) default_post('user_id', 0);

--- a/http_server/guild_leave.php
+++ b/http_server/guild_leave.php
@@ -4,15 +4,16 @@ header("Content-type: text/plain");
 
 require_once GEN_HTTP_FNS;
 
+$token = default_get('token');
 $ip = get_ip();
 
 $ret = new stdClass();
 $ret->success = false;
 
 try {
-    // check for post
-    if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
-        throw new Exception('Invalid request method.');
+    // check for token presence
+    if (is_empty($token)) {
+        throw new Exception('No token was received.');
     }
 
     // get and validate referrer
@@ -21,7 +22,7 @@ try {
     // rate limiting
     rate_limit('guild-leave-attempt-'.$ip, 5, 1);
 
-    // connect to the db
+    // connect
     $pdo = pdo_connect();
 
     // get their login

--- a/http_server/guild_leave.php
+++ b/http_server/guild_leave.php
@@ -11,11 +11,6 @@ $ret = new stdClass();
 $ret->success = false;
 
 try {
-    // check for token presence
-    if (is_empty($token)) {
-        throw new Exception('No token was received.');
-    }
-
     // get and validate referrer
     require_trusted_ref('leave your guild');
 
@@ -30,7 +25,7 @@ try {
     $account = user_select_expanded($pdo, $user_id);
 
     // sanity check
-    if ($account->guild == 0) {
+    if ((int) $account->guild === 0) {
         throw new Exception('You are not a member of a guild.');
     }
 

--- a/http_server/login.php
+++ b/http_server/login.php
@@ -19,7 +19,7 @@ require_once QUERIES_DIR . '/servers.php';
 $encrypted_login = default_post('i', '');
 $version = default_post('version', '');
 $in_token = find('token');
-$allowed_versions = array('24-dec-2013-v1', '19-jan-2019-v152');
+$allowed_versions = array('19-jan-2019-v152');
 $guest_login = false;
 $token_login = false;
 $has_email = false;
@@ -154,8 +154,8 @@ try {
 
     // if a mod, get their trial mod status
     if ($group === 2) {
-        $unpub = (int) mod_power_select($pdo, $user_id, true)->can_unpublish_level;
-        $user->trial_mod = $unpub === 1 ? false : true;
+        $unpub = (bool) (int) mod_power_select($pdo, $user_id, true)->can_unpublish_level;
+        $user->trial_mod = !$unpub;
     }
 
     // get their pr2 and epic_upgrades info

--- a/http_server/logout.php
+++ b/http_server/logout.php
@@ -24,7 +24,9 @@ try {
     // client has token, token sent via post
     if (!is_empty($_POST['token']) && is_empty($data)) {
         $ret->errorType = 'token';
-        token_delete($pdo, $token);
+        if (token_delete($pdo, $token, true) === false) {
+            throw new Exception('This token does not exist in the database. Please log in again.');
+        }
         setcookie("token", "", time() - 3600);
     } // client doesn't have token, user pass is used to verify an token logout from cookie instead
     elseif (isset($data)) {

--- a/http_server/logout.php
+++ b/http_server/logout.php
@@ -25,7 +25,7 @@ try {
     if (!is_empty($_POST['token']) && is_empty($data)) {
         $ret->errorType = 'token';
         if (token_delete($pdo, $token, true) === false) {
-            throw new Exception('This token does not exist in the database. Please log in again.');
+            throw new Exception('Could not find this token in the database.');
         }
         setcookie("token", "", time() - 3600);
     } // client doesn't have token, user pass is used to verify an token logout from cookie instead

--- a/http_server/messages_get.php
+++ b/http_server/messages_get.php
@@ -5,8 +5,8 @@ header("Content-type: text/plain");
 require_once GEN_HTTP_FNS;
 require_once QUERIES_DIR . '/messages.php';
 
-$start = (int) default_get('start', 0);
-$count = (int) default_get('count', 10);
+$start = (int) find_no_cookie('start', 0);
+$count = (int) find_no_cookie('count', 10);
 $ip = get_ip();
 
 $ret = new stdClass();

--- a/http_server/mod/ban_edit.php
+++ b/http_server/mod/ban_edit.php
@@ -39,13 +39,13 @@ try {
 
         // action log
         $acc = check_value($account_ban, 1);
-        $ip = check_value($ip_ban, 1);
+        $ipc = check_value($ip_ban, 1);
         $notes = is_empty($notes) ? 'no notes' : "notes: $notes";
 
         // record the change
         $mod_id = (int) $mod->user_id;
         $mod_name = $mod->name;
-        $msg = "$mod_name edited ban $ban_id from $ip {acc_ban: $acc, ip_ban: $ip, expire_time: $expire_time, $notes}";
+        $msg = "$mod_name edited ban $ban_id from $ip {acc_ban: $acc, ip_ban: $ipc, expire_time: $expire_time, $notes}";
         mod_action_insert($pdo, $mod_id, $msg, 0, $ip);
 
         // redirect to the ban listing

--- a/http_server/place_artifact.php
+++ b/http_server/place_artifact.php
@@ -3,7 +3,7 @@
 header("Content-type: text/plain");
 
 require_once GEN_HTTP_FNS;
-require_once QUERIES_DIR . '/artifact_locations.php';
+require_once QUERIES_DIR . '/artifact_location.php';
 
 $x = (int) default_post('x', 0);
 $y = (int) default_post('y', 0);

--- a/http_server/vault/vault_finalize.php
+++ b/http_server/vault/vault_finalize.php
@@ -4,6 +4,10 @@ header("Content-type: text/plain");
 
 require_once GEN_HTTP_FNS;
 require_once HTTP_FNS . '/pages/vault/vault_fns.php';
+require_once QUERIES_DIR . '/messages.php';
+require_once QUERIES_DIR . '/purchases.php';
+require_once QUERIES_DIR . '/rank_token_rentals.php';
+require_once QUERIES_DIR . '/servers.php';
 
 $game_auth_token = find('game_auth_token');
 $kong_user_id = find('kong_user_id');

--- a/http_server/vault/vault_super_booster.php
+++ b/http_server/vault/vault_super_booster.php
@@ -2,8 +2,8 @@
 
 header("Content-type: text/plain");
 
-require_once HTTP_FNS . '/all_fns.php';
-require_once QUERIES_DIR . '/servers/server_select.php';
+require_once GEN_HTTP_FNS;
+require_once QUERIES_DIR . '/servers.php';
 
 $server_id = (int) default_get('server_id', 0);
 $ip = get_ip();
@@ -25,7 +25,7 @@ try {
     $pdo = pdo_connect();
 
     // get user id
-    $user_id = token_login($pdo, false);
+    $user_id = (int) token_login($pdo, false);
 
     // more rate limiting
     rate_limit('super-booster-'.$user_id, 60, 1, $rl_msg);

--- a/multiplayer_server/ChatMessage.php
+++ b/multiplayer_server/ChatMessage.php
@@ -847,7 +847,7 @@ class ChatMessage
 
 
     // order campaign levels
-    private function orderCampaignLevels($a, $b)
+    protected function orderCampaignLevels($a, $b)
     {
         if ($a->level_num === $b->level_num) {
             return 0;

--- a/multiplayer_server/ChatMessage.php
+++ b/multiplayer_server/ChatMessage.php
@@ -61,21 +61,14 @@ class ChatMessage
     // special text emotes
     private function handleEmotes()
     {
-        $think_array = [':thinking:', ':think:', ':what:', ':hmm:'];
-        $lol_array = [':lol:', ':laugh:', ':lmao:', ':joy:'];
-        $fred_array = [':fred:', ':cactus:'];
-        $yay_array = [':yay:', ':woohoo:', ':wow:'];
-        $hooray_array = [':hooray:', ':tada:', ':party:'];
-        $hello_array = [':hi:', ':hello:', ':hey:'];
-
         $this->message = str_ireplace(':shrug:', '¯\_(ツ)_/¯', $this->message);
         $this->message = str_ireplace(':lenny:', '( ͡° ͜ʖ ͡°)', $this->message);
-        $this->message = str_ireplace($yay_array, '╰(ᴖ◡ᴖ)╯', $this->message);
-        $this->message = str_ireplace($hello_array, 'ー( ◉▽◉ )ﾉ', $this->message);
-        $this->message = str_ireplace($think_array, '🤔', $this->message);
-        $this->message = str_ireplace($lol_array, '😂', $this->message);
-        $this->message = str_ireplace($hooray_array, '🎉', $this->message);
-        $this->message = str_ireplace($fred_array, '🌵', $this->message);
+        $this->message = str_ireplace([':yay:', ':woohoo:', ':wow:'], '╰(ᴖ◡ᴖ)╯', $this->message);
+        $this->message = str_ireplace([':hi:', ':hello:', ':hey:'], 'ー( ◉▽◉ )ﾉ', $this->message);
+        $this->message = str_ireplace([':thinking:', ':think:', ':what:', ':hmm:'], '🤔', $this->message);
+        $this->message = str_ireplace([':lol:', ':laugh:', ':lmao:', ':joy:'], '😂', $this->message);
+        $this->message = str_ireplace([':hooray:', ':tada:', ':party:'], '🎉', $this->message);
+        $this->message = str_ireplace([':fred:', ':cactus:'], '🌵', $this->message);
     }
 
 
@@ -216,13 +209,14 @@ class ChatMessage
     // advanced information for admins
     private function commandAdminDebug()
     {
-        global $server_id, $server_name, $uptime, $port, $guild_id, $guild_owner, $server_expire_time;
+        global $server_id, $server_name, $uptime, $port, $guild_id, $guild_owner, $server_expire_time, $campaign_array;
 
         $is_ps = ($guild_id !== 0 && $guild_id !== 183) ? 'yes' : 'no';
         if ($this->message === '/debug help') {
             $this->write(
                 "systemChat`Acceptable Arguments:<br><br>".
                 "- help<br>".
+                "- campaign<br>".
                 "- player *name*<br>".
                 "- server"
             );
@@ -239,6 +233,30 @@ class ChatMessage
                 "server_owner: $guild_owner<br>".
                 "server_expire_time: $server_expires"
             );
+        } elseif (strpos($this->message, '/debug campaign') === 0) {
+            $campaign = json_decode(json_encode($campaign_array));
+            $ret = "";
+            foreach (range(1, 6) as $campaign_id) {
+                ${"c" . $campaign_id . "_arr"} = array();
+            }
+            foreach ($campaign as $level) {
+                array_push(${"c" . $level->campaign . "_arr"}, $level);
+            }
+            foreach (range(1, 6) as $campaign_id) {
+                $levels = json_decode(json_encode(${"c" . $campaign_id . "_arr"}));
+                if (empty($levels)) {
+                    $ret .= "No levels for campaign #$campaign_id.<br><br>";
+                } else {
+                    usort($levels, array($this, "orderCampaignLevels"));
+                    $ret .= "Campaign #$campaign_id:";
+                    foreach ($levels as $level) {
+                        $ret .= "<br>Level $level->level_num (ID: $level->level_id)"
+                            ." | Prize: $level->prize_type #$level->prize_id ($level->prize)";
+                    }
+                    $ret .= '<br><br>';
+                }
+            }
+            $this->write("message`$ret");
         } elseif (strpos($this->message, '/debug player ') === 0) {
             $player_name = trim(substr($this->message, 14));
             $player = name_to_player($player_name);
@@ -825,6 +843,16 @@ class ChatMessage
     {
         $player = isset($player) ? $player : $this->player;
         return ($player->group === 3 && $player->server_owner === true) ? true : false;
+    }
+
+
+    // order campaign levels
+    private function orderCampaignLevels($a, $b)
+    {
+        if ($a->level_num === $b->level_num) {
+            return 0;
+        }
+        return $a->level_num < $b->level_num ? -1 : 1;
     }
 
 

--- a/multiplayer_server/ChatMessage.php
+++ b/multiplayer_server/ChatMessage.php
@@ -17,9 +17,9 @@ class ChatMessage
         $this->from_id = $this->player->user_id;
         $this->message = $chat_message;
 
-        // sanity check: is the message more than 100 characters?
-        if (strlen($this->message) > 100) {
-            $this->message = substr($this->message, 0, 100);
+        // sanity check: is the message more than 150 characters?
+        if (strlen($this->message) > 150) {
+            $this->message = substr($this->message, 0, 150);
         }
 
         // find what room the player is in

--- a/multiplayer_server/Player.php
+++ b/multiplayer_server/Player.php
@@ -251,7 +251,7 @@ class Player
     {
         $seconds = time() - $this->chat_time;
         $this->chat_count -= $seconds / 2;
-        $this->chat_count = $this->chat_count >= 0 ?: 0;
+        $this->chat_count = $this->chat_count >= 0 ? $this->chat_count : 0;
         return $this->chat_count;
     }
 

--- a/multiplayer_server/Player.php
+++ b/multiplayer_server/Player.php
@@ -173,7 +173,7 @@ class Player
         }
 
         // if they're a trial, tell the client
-        if ($this->group === 2 && isset($login->user->trial_mod)) {
+        if ($this->group === 2 && $login->user->trial_mod) {
             $this->trial_mod = true;
             $this->write("becomeTrialMod`");
         }


### PR DESCRIPTION
### Things that work again
 - Setting the Campaign
 - Level deletion (saving/loading works as intended in 152.3)
 - Chat auto anti-spam filter
 - Banning (and bans applying to users)
 - Unpublishing levels
 - Trial/perma mod detection
 - PMs tab pages
 - Ban edit mod logging (doesn't log the mod's IP address as yes/no)
 - All server restarts
 - Blank level listing pages (don't throw an error)
 - Guild invitations/leaving
 - Artifact placement
 - Old account deletion (monthly cron task; find in weekly.php)
 - Vault

### Five things require your attention in addition to merging this
 - All of the level music is gone from PR2hub (404 error)
 - Tournament server is down
 - None of the Campaign levels have prizes (restore your last backup of the pr2_campaigns table and just rename it to campaigns)
 - Please restore the recent_logins table. This will continue to help us do our jobs diligently [with IP comparison], and will also allow us to verify more account recoveries. With PRF on the horizon, we want to be able to process as many of these as we can. :pray:
 - Please make sure the vault works!
 - Please run this query on the database (future PR2 sets smile upon you):
```mysql
ALTER TABLE pr2
  CHANGE hat_array hat_array varchar(1000),
  CHANGE head_array head_array varchar(1000),
  CHANGE body_array body_array varchar(1000),
  CHANGE feet_array feet_array varchar(1000);

ALTER TABLE epic_upgrades
  CHANGE epic_hats epic_hats varchar(1000),
  CHANGE epic_heads epic_heads varchar(1000),
  CHANGE epic_bodies epic_bodies varchar(1000),
  CHANGE epic_feet epic_feet varchar(1000);
```

### Future
 - Switch the client back to GET for messages_get.php and guild_leave.php so default_get can be used. Require explicit token for both
___

See the client repo for v152.3