### PR TITLE
Unbreak campaign prizes, vault, fah

### DIFF
--- a/common/cron/hourly.php
+++ b/common/cron/hourly.php
@@ -12,7 +12,8 @@ require_once QUERIES_DIR . '/folding_at_home.php';
 require_once QUERIES_DIR . '/messages.php';
 require_once QUERIES_DIR . '/rank_tokens.php';
 
-// remove expired servers
+// speak to servers (campaign prizes update), remove expired servers
+require_once QUERIES_DIR . '/campaigns.php';
 require_once QUERIES_DIR . '/servers.php';
 
 // tell the command line
@@ -27,6 +28,7 @@ try {
     generate_level_list($pdo, 'best');
     generate_level_list($pdo, 'best_today');
     generate_level_list($pdo, 'campaign');
+    set_campaign($pdo);
     ensure_awards($pdo);
     servers_deactivate_expired($pdo);
     servers_delete_old($pdo);

--- a/common/cron/hourly.php
+++ b/common/cron/hourly.php
@@ -6,9 +6,10 @@ require_once GEN_HTTP_FNS;
 // ensure part awards
 require_once QUERIES_DIR . '/part_awards.php';
 
-// folding_at_home data select/insert/update from/into/in db
+// folding_at_home data select/insert/update from/into/in db, send confirmation message
 require_once FNS_DIR . '/cron/cron_fns.php';
 require_once QUERIES_DIR . '/folding_at_home.php';
+require_once QUERIES_DIR . '/messages.php';
 require_once QUERIES_DIR . '/rank_tokens.php';
 
 // remove expired servers

--- a/common/cron/hourly.php
+++ b/common/cron/hourly.php
@@ -24,15 +24,15 @@ output("Hourly CRON starting at $time...");
 $pdo = pdo_connect();
 
 try {
+    servers_deactivate_expired($pdo);
+    servers_delete_old($pdo);
+    ensure_awards($pdo);
+    fah_update($pdo);
     generate_level_list($pdo, 'newest');
     generate_level_list($pdo, 'best');
     generate_level_list($pdo, 'best_today');
     generate_level_list($pdo, 'campaign');
     set_campaign($pdo);
-    ensure_awards($pdo);
-    servers_deactivate_expired($pdo);
-    servers_delete_old($pdo);
-    fah_update($pdo);
 
     // tell the command line
     output('Hourly CRON successful.');

--- a/common/cron/minute.php
+++ b/common/cron/minute.php
@@ -5,7 +5,6 @@ require_once FNS_DIR . '/cron/cron_fns.php';
 require_once HTTP_FNS . '/rand_crypt/PseudoRandom.php';
 require_once QUERIES_DIR . '/artifact_location.php';
 require_once QUERIES_DIR . '/bans.php';
-require_once QUERIES_DIR . '/campaigns.php';
 require_once QUERIES_DIR . '/gp.php';
 require_once QUERIES_DIR . '/messages.php';
 require_once QUERIES_DIR . '/servers.php';

--- a/common/cron/weekly.php
+++ b/common/cron/weekly.php
@@ -3,7 +3,7 @@
 require_once GEN_HTTP_FNS;
 require_once QUERIES_DIR . '/all_optimize.php';
 require_once QUERIES_DIR . '/bans.php';
-require_once QUERIES_DIR . '/best_levels/best_levels_reset.php';
+require_once QUERIES_DIR . '/best_levels.php';
 require_once QUERIES_DIR . '/level_backups.php';
 require_once QUERIES_DIR . '/messages.php';
 require_once QUERIES_DIR . '/new_levels.php';

--- a/common/queries/best_levels.php
+++ b/common/queries/best_levels.php
@@ -27,7 +27,7 @@ function best_levels_populate($pdo)
     $result = $pdo->exec('
         INSERT INTO best_levels
              SELECT level_id
-               FROM pr2_levels
+               FROM levels
               WHERE live = 1
                 AND votes > 1000
                 AND rating > 4.3

--- a/common/queries/part_awards.php
+++ b/common/queries/part_awards.php
@@ -1,33 +1,6 @@
 <?php
 
 
-function ensure_awards($pdo)
-{
-    // select all records, they get cleared out weekly or somesuch
-    $awards = part_awards_select_list($pdo);
-
-    // give users their awards
-    foreach ($awards as $row) {
-        if ($row->part == 0) {
-            $part = '*';
-        } else {
-            $part = $row->part;
-        }
-        $type = $row->type;
-        $user_id = $row->user_id;
-        try {
-            award_part($pdo, $user_id, $type, $part, false);
-            echo "user_id: $user_id, type: $type, part: $part \n";
-        } catch (Exception $e) {
-            echo "Error: $e \n";
-        }
-    }
-
-    // delete older records
-    part_awards_delete_old($pdo);
-}
-
-
 function part_awards_delete_old($pdo)
 {
     $result = $pdo->exec('

--- a/functions/cron/cron_fns.php
+++ b/functions/cron/cron_fns.php
@@ -13,7 +13,6 @@ function run_update_cycle($pdo)
     $send->artifact = artifact_location_select($pdo);
     $send->recent_pms = get_recent_pms($pdo);
     $send->recent_bans = bans_select_recent($pdo);
-    $send->campaign = levels_select_campaign($pdo);
     $send_str = json_encode($send);
 
     // send the data

--- a/functions/cron/cron_fns.php
+++ b/functions/cron/cron_fns.php
@@ -216,6 +216,33 @@ function failover_servers($pdo)
 }
 
 
+function set_campaign($pdo)
+{
+    output("Starting campaign update process...");
+
+    // get campaign data
+    $send = new stdClass();
+    $send->campaign = campaign_select($pdo);
+    $send = json_encode($send);
+
+    // send update function to the servers
+    $servers = servers_select($pdo);
+    foreach ($servers as $server) {
+        output("Updating campaign on $server->server_name (ID: #$server->server_id)...");
+        try {
+            $reply = talk_to_server($server->address, $server->port, $server->salt, "set_campaign`$send", true, false);
+            output("Reply: $reply");
+            output("$server->server_name (ID #$server->server_id) campaign update successful.");
+        } catch (Exception $e) {
+            output($e->getMessage());
+        }
+    }
+
+    // tell the command line
+    output('Campaign update complete.');
+}
+
+
 function ensure_awards($pdo)
 {
     // select all records, they get cleared out weekly or somesuch

--- a/functions/cron/cron_fns.php
+++ b/functions/cron/cron_fns.php
@@ -216,6 +216,29 @@ function failover_servers($pdo)
 }
 
 
+function ensure_awards($pdo)
+{
+    // select all records, they get cleared out weekly or somesuch
+    $awards = part_awards_select_list($pdo);
+
+    // give users their awards
+    foreach ($awards as $row) {
+        $part = (int) $row->part === 0 ? '*' : $row->part;
+        $type = $row->type;
+        $user_id = (int) $row->user_id;
+        try {
+            award_part($pdo, $user_id, $type, $part, false);
+            echo "user_id: $user_id, type: $type, part: $part \n";
+        } catch (Exception $e) {
+            echo "Error: $e \n";
+        }
+    }
+
+    // delete older records
+    part_awards_delete_old($pdo);
+}
+
+
 function servers_restart_all($pdo)
 {
     // tell the command line

--- a/functions/http_fns/query_fns.php
+++ b/functions/http_fns/query_fns.php
@@ -349,7 +349,7 @@ function generate_level_list($pdo, $mode)
     foreach (range(0, 8) as $j) {
         $str = format_level_list(array_slice($levels, $j * 9, 9));
         $filename = $dir . ($j + 1);
-        $ret = (bool) file_put_contents($filename, $str);
+        $ret = file_put_contents($filename, $str);
         if ($ret === false) {
             throw new Exception("Could not write level list to $filename.");
         }

--- a/functions/multi_fns/client/lobby.php
+++ b/functions/multi_fns/client/lobby.php
@@ -164,7 +164,7 @@ function client_ignore_user($socket, $data)
 {
     $player = $socket->getPlayer();
     $ignored_player = name_to_player($data);
-    if (isset($ignored_player)) {
+    if (isset($ignored_player) && $ignored_player !== $player) {
         array_push($player->ignored_array, $ignored_player->user_id);
     }
 }

--- a/functions/multi_fns/process_fns.php
+++ b/functions/multi_fns/process_fns.php
@@ -90,7 +90,6 @@ function process_update_cycle($socket, $data)
         place_artifact($obj->artifact);
         pm_notify($obj->recent_pms);
         apply_bans($obj->recent_bans);
-        set_campaign($obj->campaign);
 
         $ret = new stdClass();
         $ret->plays = drain_plays();

--- a/functions/multi_fns/process_fns.php
+++ b/functions/multi_fns/process_fns.php
@@ -69,6 +69,17 @@ function process_message_player($socket, $data)
 }
 
 
+// set the campaign
+function process_set_campaign($socket, $data)
+{
+    if ($socket->process === true) {
+        $obj = json_decode($data);
+        set_campaign((object) $obj->campaign);
+        $socket->write('Campaign updated.');
+    }
+}
+
+
 // clear player's daily exp levels
 function process_start_new_day($socket)
 {

--- a/http_server/admin/set_campaign.php
+++ b/http_server/admin/set_campaign.php
@@ -7,7 +7,7 @@ require_once QUERIES_DIR . '/admin_actions.php';
 require_once QUERIES_DIR . '/campaigns.php';
 
 $action = default_post('action', 'lookup');
-$message = htmlspecialchars(default_post('message', ''));
+$message = htmlspecialchars(default_get('message', ''));
 $campaign_id = 6; // 1 = Original, 2 = Speed, 3 = Luna, 4 = Timeline, 5 = Legendary, 6 = Custom
 
 try {

--- a/http_server/login.php
+++ b/http_server/login.php
@@ -19,7 +19,7 @@ require_once QUERIES_DIR . '/servers.php';
 $encrypted_login = default_post('i', '');
 $version = default_post('version', '');
 $in_token = find('token');
-$allowed_versions = array('31-jan-2019-v153');
+$allowed_versions = array('14-feb-2019-v153-1');
 $guest_login = false;
 $token_login = false;
 $has_email = false;

--- a/http_server/register_user.php
+++ b/http_server/register_user.php
@@ -5,7 +5,7 @@ require_once HTTP_FNS . '/rand_crypt/to_hash.php';
 require_once QUERIES_DIR . '/bans.php';
 require_once QUERIES_DIR . '/messages.php';
 
-$name = default_post('name');
+$name = trim(default_post('name'));
 $password = default_post('password');
 $time = time();
 $ip = get_ip();

--- a/http_server/vault/vault_finalize.php
+++ b/http_server/vault/vault_finalize.php
@@ -5,6 +5,7 @@ header("Content-type: text/plain");
 require_once GEN_HTTP_FNS;
 require_once HTTP_FNS . '/pages/vault/vault_fns.php';
 require_once QUERIES_DIR . '/messages.php';
+require_once QUERIES_DIR . '/part_awards.php';
 require_once QUERIES_DIR . '/purchases.php';
 require_once QUERIES_DIR . '/rank_token_rentals.php';
 require_once QUERIES_DIR . '/servers.php';

--- a/multiplayer_server/parts/Prizes.php
+++ b/multiplayer_server/parts/Prizes.php
@@ -674,7 +674,7 @@ class Prizes
     {
         $match = null;
         foreach (self::$arr as $prize) {
-            if ($prize->getType() === $type && $prize->getId() === $id) {
+            if ($prize->getType() === $type && $prize->getId() === (int) $id) {
                 $match = $prize;
                 break;
             }

--- a/multiplayer_server/parts/Prizes.php
+++ b/multiplayer_server/parts/Prizes.php
@@ -400,7 +400,7 @@ class Prizes
         self::$EPIC_PROPELLER_HAT = new Prize(self::TYPE_EPIC_HAT, Hats::PROPELLER, 'Epic Upgrade!');
         self::$EPIC_COWBOY_HAT = new Prize(self::TYPE_EPIC_HAT, Hats::COWBOY, 'Epic Upgrade!');
         self::$EPIC_CROWN_HAT = new Prize(self::TYPE_EPIC_HAT, Hats::CROWN, 'Epic Upgrade!');
-        self::$EPIC_SANTA_HAT = new Prize(self::TYPE_EPIC_HAT, Hats::SANTA, 'Epic Upgrade!');
+        self::$EPIC_SANTA_HAT = new Prize(self::TYPE_EPIC_HAT, Hats::SANTA, 'Epic Upgrade!', '', true);
         self::$EPIC_PARTY_HAT = new Prize(self::TYPE_EPIC_HAT, Hats::PARTY, 'Epic Upgrade!');
         self::$EPIC_TOP_HAT = new Prize(self::TYPE_EPIC_HAT, Hats::TOP_HAT, 'Epic Upgrade!');
         self::$EPIC_JUMP_START_HAT = new Prize(self::TYPE_EPIC_HAT, Hats::JUMP_START, 'Epic Upgrade!', '', true);

--- a/multiplayer_server/rooms/Game.php
+++ b/multiplayer_server/rooms/Game.php
@@ -1146,8 +1146,10 @@ class Game extends Room
     public function remove()
     {
         foreach ($this as $key => $var) {
-            $this->$key = null;
-            unset($this->$key, $key, $var);
+            if ($key !== 'mode') {
+                $this->$key = null;
+                unset($this->$key, $key, $var);
+            }
         }
 
         parent::remove();


### PR DESCRIPTION
The query in the CRON was breaking campaign prizes updates, so I fixed it and made it update hourly instead of every minute (the campaign will never be changing that frequently). Additionally, admins can now manually update the campaign prizes with `/debug campaign refresh`, so there's no need for this.

Things that should also be quick:
 - PR2 v153.1 is up at the client repo
 - Please make a new permanent private server for guild id no. 205 (Beta Testers) so that I can start pushing betas to JV2 for testing
 - Tournament server is down
 - Random question: what is the title/artist of the original Baking Games intro song?
 - ***Please run this query on the database to prevent errors:***
```mysql
ALTER TABLE pr2
  CHANGE hat_array hat_array varchar(1000) NOT NULL DEFAULT '1',
  CHANGE head_array head_array varchar(1000) NOT NULL DEFAULT '1,2,3,4,5,6,7,8,9',
  CHANGE body_array body_array varchar(1000) NOT NULL DEFAULT '1,2,3,4,5,6,7,8,9',
  CHANGE feet_array feet_array varchar(1000) NOT NULL DEFAULT '1,2,3,4,5,6,7,8,9';

ALTER TABLE epic_upgrades
  CHANGE epic_hats epic_hats varchar(1000),
  CHANGE epic_heads epic_heads varchar(1000),
  CHANGE epic_bodies epic_bodies varchar(1000),
  CHANGE epic_feet epic_feet varchar(1000);
```

Things that won't be as quick but need to be fixed:
 - The email issue with hotmail/live email addresses is still a thing (the email I sent you with the subject "URGENT: Emails undeliverable to hotmail/outlook/live addresses"

Wishful thinking:
 - Please consider giving me limited SSH/DB access so I can perform administrative tasks such as pushing new updates and diagnosing server problems.
 - Please restore the recent_logins table. This will continue to help us do our jobs diligently [with IP comparison], and will also allow us to verify more account recoveries. With PRF on the horizon, we want to be able to process as many of these as we can. :pray: