### PR TITLE
allow systemChat in races

### DIFF
--- a/multiplayer_server/rooms/Game.php
+++ b/multiplayer_server/rooms/Game.php
@@ -1024,13 +1024,13 @@ class Game extends Room
         }
     }
 
-    public function sendChat($message, $user_id)
+    public function sendChat($message, $user_id = -1)
     {
         // any added backticks will cut off the end of $text
         list($command, $name, $power, $text) = explode('`', $message);
 
         // send the message
-        if ($command === 'chat') {
+        if ($command === 'chat' || $command === 'systemChat') {
             foreach ($this->player_array as $player) {
                 if (!$player->isIgnoredId($user_id)) {
                     $player->socket->write("$command`$name`$power`$text");


### PR DESCRIPTION
Not sure why this wasn't a thing before now. I was testing something on my local machine and the next thing I know the whole server crashes because there were too few arguments passed to `sendChat`.