### PR TITLE
Fix rogue dropped hat message

### DIFF
--- a/multiplayer_server/rooms/Game.php
+++ b/multiplayer_server/rooms/Game.php
@@ -1388,6 +1388,7 @@ class Game extends Room
             if ($this->mode === self::MODE_HAT
                 && $this->hasHats == $player->temp_id
                 && $this->currentMS() < $this->hatCountdownEnd
+                && !$this->isLastPlayer($player)
             ) {
                 $this->cancelHatCountdown();
             }


### PR DESCRIPTION
The message shouldn't show when the player is the last player in the game.