### PR TITLE
Reform EXP gain w/ tokens

### DIFF
--- a/http_server/get_player_info.php
+++ b/http_server/get_player_info.php
@@ -119,7 +119,7 @@ try {
     }
 
     $ret->exp_points = $target->exp_points;
-    $ret->exp_to_rank = exp_required_for_ranking($active_rank + 1);
+    $ret->exp_to_rank = exp_required_for_ranking($target->rank + 1);
     $ret->friend = $friend;
     $ret->ignored = $ignored;
 } catch (Exception $e) {

--- a/multiplayer_server/Player.php
+++ b/multiplayer_server/Player.php
@@ -46,7 +46,7 @@ class Player
     public $speed;
     public $acceleration;
     public $jumping;
-    
+
     public $hh_speed;
     public $hh_acceleration;
     public $hh_jumping;
@@ -244,7 +244,7 @@ class Player
         $ret->bodyColor2 = $this->getSecondColor('body', $this->body);
         $ret->feetColor2 = $this->getSecondColor('feet', $this->feet);
         $ret->exp_points = $this->exp_points;
-        $ret->exp_to_rank = exp_required_for_ranking($this->active_rank + 1);
+        $ret->exp_to_rank = exp_required_for_ranking($this->rank + 1);
 
         return $ret;
     }
@@ -264,7 +264,7 @@ class Player
 
     public function incExp($exp)
     {
-        $max_rank = exp_required_for_ranking($this->active_rank + 1);
+        $max_rank = exp_required_for_ranking($this->rank + 1);
         $new_exp_total = $this->exp_points + $exp;
         $this->write("setExpGain`$this->exp_points`$new_exp_total`$max_rank");
         $this->exp_points += $exp;
@@ -620,7 +620,7 @@ class Player
         if (!isset($this->user_id)) {
             return false;
         }
-        
+
         $eType = 'e'.ucfirst($type);
         $part = $this->{$type};
 
@@ -631,7 +631,7 @@ class Player
             $parts_available = $this->getFullParts($type);
             $epic_parts_available = $this->getFullParts($eType);
         }
-        
+
         if (array_search($part, $parts_available) === false) {
             $part = $parts_available[0];
             $this->{$type} = $part;


### PR DESCRIPTION
This pull:
 - Fixes a bug with contest prize EXP awarding that would sometimes set the player's EXP points to the prize amount if they ranked up at least once in the process.
 - Implements: https://jiggmin2.com/forums/showthread.php?tid=2998

Additionally, when rank tokens are enabled, the server will now use the player's base instead of active rank EXP progress for ranking and display. This means players won't have to decrease their rank tokens to rank up anymore and rank progress on popups/after races will use the player's base rank.