### PR TITLE
Fix backup version bug

### DIFF
--- a/http_server/upload_level.php
+++ b/http_server/upload_level.php
@@ -206,7 +206,7 @@ try {
                 $s3,
                 $user_id,
                 $level_id,
-                $level->version - 1,
+                (int) $level->version,
                 $title,
                 (int) $level->live,
                 (float) $level->rating,


### PR DESCRIPTION
Levels now back up as their current version, not the one prior.